### PR TITLE
Make activation function configurable as argument

### DIFF
--- a/ice_station_zebra/models/common/activations.py
+++ b/ice_station_zebra/models/common/activations.py
@@ -1,6 +1,6 @@
-import torch.nn as nn
+from torch import nn
 
-ACTIVATIONS = {
+ACTIVATION_FROM_NAME: dict[str, type[nn.Module]] = {
     "ReLU": nn.ReLU,
     "LeakyReLU": nn.LeakyReLU,
     "ELU": nn.ELU,
@@ -9,9 +9,3 @@ ACTIVATIONS = {
     "Sigmoid": nn.Sigmoid,
     "Tanh": nn.Tanh,
 }
-
-
-def get_activation(name: str) -> nn.Module:
-    if name not in ACTIVATIONS:
-        raise ValueError(f"Unsupported activation: {name}")
-    return ACTIVATIONS[name]()

--- a/ice_station_zebra/models/common/activations.py
+++ b/ice_station_zebra/models/common/activations.py
@@ -10,6 +10,7 @@ ACTIVATIONS = {
     "Tanh": nn.Tanh,
 }
 
+
 def get_activation(name: str) -> nn.Module:
     if name not in ACTIVATIONS:
         raise ValueError(f"Unsupported activation: {name}")

--- a/ice_station_zebra/models/common/activations.py
+++ b/ice_station_zebra/models/common/activations.py
@@ -1,0 +1,16 @@
+import torch.nn as nn
+
+ACTIVATIONS = {
+    "ReLU": nn.ReLU,
+    "LeakyReLU": nn.LeakyReLU,
+    "ELU": nn.ELU,
+    "GELU": nn.GELU,
+    "SiLU": nn.SiLU,       
+    "Sigmoid": nn.Sigmoid,
+    "Tanh": nn.Tanh,
+}
+
+def get_activation(name: str) -> nn.Module:
+    if name not in ACTIVATIONS:
+        raise ValueError(f"Unsupported activation: {name}")
+    return ACTIVATIONS[name]()

--- a/ice_station_zebra/models/common/activations.py
+++ b/ice_station_zebra/models/common/activations.py
@@ -5,7 +5,7 @@ ACTIVATIONS = {
     "LeakyReLU": nn.LeakyReLU,
     "ELU": nn.ELU,
     "GELU": nn.GELU,
-    "SiLU": nn.SiLU,       
+    "SiLU": nn.SiLU,
     "Sigmoid": nn.Sigmoid,
     "Tanh": nn.Tanh,
 }

--- a/ice_station_zebra/models/common/bottleneckblock.py
+++ b/ice_station_zebra/models/common/bottleneckblock.py
@@ -1,5 +1,6 @@
 import torch.nn as nn
 from torch import Tensor
+
 from .activations import get_activation
 
 

--- a/ice_station_zebra/models/common/bottleneckblock.py
+++ b/ice_station_zebra/models/common/bottleneckblock.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 import torch.nn as nn
 from torch import Tensor
 from .activations import get_activation

--- a/ice_station_zebra/models/common/bottleneckblock.py
+++ b/ice_station_zebra/models/common/bottleneckblock.py
@@ -1,7 +1,7 @@
 import torch.nn as nn
 from torch import Tensor
 
-from .activations import get_activation
+from .activations import ACTIVATION_FROM_NAME
 
 
 class BottleneckBlock(nn.Module):
@@ -15,18 +15,17 @@ class BottleneckBlock(nn.Module):
     ) -> None:
         super().__init__()
 
-        def act():
-            return get_activation(activation)
+        activation_layer = ACTIVATION_FROM_NAME[activation]
 
         self.model = nn.Sequential(
             nn.Conv2d(
                 in_channels, out_channels, kernel_size=filter_size, padding="same"
             ),
-            act(),
+            activation_layer(inplace=True),
             nn.Conv2d(
                 out_channels, out_channels, kernel_size=filter_size, padding="same"
             ),
-            act(),
+            activation_layer(inplace=True),
             nn.BatchNorm2d(num_features=out_channels),
         )
 

--- a/ice_station_zebra/models/common/bottleneckblock.py
+++ b/ice_station_zebra/models/common/bottleneckblock.py
@@ -1,6 +1,6 @@
+from typing import Type
 import torch.nn as nn
 from torch import Tensor
-from typing import Type
 
 class BottleneckBlock(nn.Module):
     def __init__(

--- a/ice_station_zebra/models/common/bottleneckblock.py
+++ b/ice_station_zebra/models/common/bottleneckblock.py
@@ -14,7 +14,8 @@ class BottleneckBlock(nn.Module):
     ) -> None:
         super().__init__()
 
-        act = lambda: get_activation(activation)
+        def act():
+            return get_activation(activation)
 
         self.model = nn.Sequential(
             nn.Conv2d(

--- a/ice_station_zebra/models/common/bottleneckblock.py
+++ b/ice_station_zebra/models/common/bottleneckblock.py
@@ -9,7 +9,7 @@ class BottleneckBlock(nn.Module):
         out_channels: int,
         *,
         filter_size: int,
-        activation: Type[nn.Module] = nn.ReLU,  
+        activation: Type[nn.Module] = nn.ReLU,
     ) -> None:
         super().__init__()
 

--- a/ice_station_zebra/models/common/bottleneckblock.py
+++ b/ice_station_zebra/models/common/bottleneckblock.py
@@ -2,6 +2,7 @@ from typing import Type
 
 import torch.nn as nn
 from torch import Tensor
+from .activations import get_activation
 
 
 class BottleneckBlock(nn.Module):
@@ -11,19 +12,21 @@ class BottleneckBlock(nn.Module):
         out_channels: int,
         *,
         filter_size: int,
-        activation: Type[nn.Module] = nn.ReLU,
+        activation: str = "ReLU",
     ) -> None:
         super().__init__()
+
+        act = lambda: get_activation(activation)
 
         self.model = nn.Sequential(
             nn.Conv2d(
                 in_channels, out_channels, kernel_size=filter_size, padding="same"
             ),
-            activation(),
+            act(),
             nn.Conv2d(
                 out_channels, out_channels, kernel_size=filter_size, padding="same"
             ),
-            activation(),
+            act(),
             nn.BatchNorm2d(num_features=out_channels),
         )
 

--- a/ice_station_zebra/models/common/bottleneckblock.py
+++ b/ice_station_zebra/models/common/bottleneckblock.py
@@ -1,6 +1,8 @@
 from typing import Type
+
 import torch.nn as nn
 from torch import Tensor
+
 
 class BottleneckBlock(nn.Module):
     def __init__(

--- a/ice_station_zebra/models/common/bottleneckblock.py
+++ b/ice_station_zebra/models/common/bottleneckblock.py
@@ -1,6 +1,6 @@
 import torch.nn as nn
 from torch import Tensor
-
+from typing import Type
 
 class BottleneckBlock(nn.Module):
     def __init__(
@@ -9,6 +9,7 @@ class BottleneckBlock(nn.Module):
         out_channels: int,
         *,
         filter_size: int,
+        activation: Type[nn.Module] = nn.ReLU,  
     ) -> None:
         super().__init__()
 
@@ -16,11 +17,11 @@ class BottleneckBlock(nn.Module):
             nn.Conv2d(
                 in_channels, out_channels, kernel_size=filter_size, padding="same"
             ),
-            nn.ReLU(inplace=True),
+            activation(),
             nn.Conv2d(
                 out_channels, out_channels, kernel_size=filter_size, padding="same"
             ),
-            nn.ReLU(inplace=True),
+            activation(),
             nn.BatchNorm2d(num_features=out_channels),
         )
 

--- a/ice_station_zebra/models/common/convblock.py
+++ b/ice_station_zebra/models/common/convblock.py
@@ -1,3 +1,4 @@
+from typing import Type
 import torch.nn as nn
 from torch import Tensor
 from typing import Type

--- a/ice_station_zebra/models/common/convblock.py
+++ b/ice_station_zebra/models/common/convblock.py
@@ -15,7 +15,9 @@ class ConvBlock(nn.Module):
     ) -> None:
         super().__init__()
 
-        act = lambda: get_activation(activation)
+        def act():
+            return get_activation(activation)
+
 
         layers = [
             nn.Conv2d(

--- a/ice_station_zebra/models/common/convblock.py
+++ b/ice_station_zebra/models/common/convblock.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 import torch.nn as nn
 from torch import Tensor
 from .activations import get_activation

--- a/ice_station_zebra/models/common/convblock.py
+++ b/ice_station_zebra/models/common/convblock.py
@@ -1,6 +1,6 @@
 import torch.nn as nn
 from torch import Tensor
-
+from typing import Type
 
 class ConvBlock(nn.Module):
     def __init__(
@@ -10,6 +10,7 @@ class ConvBlock(nn.Module):
         *,
         filter_size: int,
         final: bool = False,
+        activation: Type[nn.Module] = nn.ReLU,  
     ) -> None:
         super().__init__()
 
@@ -17,11 +18,11 @@ class ConvBlock(nn.Module):
             nn.Conv2d(
                 in_channels, out_channels, kernel_size=filter_size, padding="same"
             ),
-            nn.ReLU(inplace=True),
+            activation(),
             nn.Conv2d(
                 out_channels, out_channels, kernel_size=filter_size, padding="same"
             ),
-            nn.ReLU(inplace=True),
+            activation(),
         ]
         if final:
             layers += [
@@ -31,7 +32,7 @@ class ConvBlock(nn.Module):
                     kernel_size=filter_size,
                     padding="same",
                 ),
-                nn.ReLU(inplace=True),
+                activation(),
             ]
 
         else:

--- a/ice_station_zebra/models/common/convblock.py
+++ b/ice_station_zebra/models/common/convblock.py
@@ -1,5 +1,6 @@
 import torch.nn as nn
 from torch import Tensor
+
 from .activations import get_activation
 
 
@@ -17,7 +18,6 @@ class ConvBlock(nn.Module):
 
         def act():
             return get_activation(activation)
-
 
         layers = [
             nn.Conv2d(

--- a/ice_station_zebra/models/common/convblock.py
+++ b/ice_station_zebra/models/common/convblock.py
@@ -11,7 +11,7 @@ class ConvBlock(nn.Module):
         *,
         filter_size: int,
         final: bool = False,
-        activation: Type[nn.Module] = nn.ReLU,  
+        activation: Type[nn.Module] = nn.ReLU,
     ) -> None:
         super().__init__()
 

--- a/ice_station_zebra/models/common/convblock.py
+++ b/ice_station_zebra/models/common/convblock.py
@@ -1,7 +1,7 @@
 import torch.nn as nn
 from torch import Tensor
 
-from .activations import get_activation
+from .activations import ACTIVATION_FROM_NAME
 
 
 class ConvBlock(nn.Module):
@@ -16,18 +16,17 @@ class ConvBlock(nn.Module):
     ) -> None:
         super().__init__()
 
-        def act():
-            return get_activation(activation)
+        activation_layer = ACTIVATION_FROM_NAME[activation]
 
         layers = [
             nn.Conv2d(
                 in_channels, out_channels, kernel_size=filter_size, padding="same"
             ),
-            act(),
+            activation_layer(inplace=True),
             nn.Conv2d(
                 out_channels, out_channels, kernel_size=filter_size, padding="same"
             ),
-            act(),
+            activation_layer(inplace=True),
         ]
         if final:
             layers += [
@@ -37,7 +36,7 @@ class ConvBlock(nn.Module):
                     kernel_size=filter_size,
                     padding="same",
                 ),
-                act(),
+                activation_layer(inplace=True),
             ]
 
         else:

--- a/ice_station_zebra/models/common/convblock.py
+++ b/ice_station_zebra/models/common/convblock.py
@@ -2,6 +2,7 @@ from typing import Type
 
 import torch.nn as nn
 from torch import Tensor
+from .activations import get_activation
 
 
 class ConvBlock(nn.Module):
@@ -12,19 +13,21 @@ class ConvBlock(nn.Module):
         *,
         filter_size: int,
         final: bool = False,
-        activation: Type[nn.Module] = nn.ReLU,
+        activation: str = "ReLU",
     ) -> None:
         super().__init__()
+
+        act = lambda: get_activation(activation)
 
         layers = [
             nn.Conv2d(
                 in_channels, out_channels, kernel_size=filter_size, padding="same"
             ),
-            activation(),
+            act(),
             nn.Conv2d(
                 out_channels, out_channels, kernel_size=filter_size, padding="same"
             ),
-            activation(),
+            act(),
         ]
         if final:
             layers += [
@@ -34,7 +37,7 @@ class ConvBlock(nn.Module):
                     kernel_size=filter_size,
                     padding="same",
                 ),
-                activation(),
+                act(),
             ]
 
         else:

--- a/ice_station_zebra/models/common/convblock.py
+++ b/ice_station_zebra/models/common/convblock.py
@@ -1,7 +1,8 @@
 from typing import Type
+
 import torch.nn as nn
 from torch import Tensor
-from typing import Type
+
 
 class ConvBlock(nn.Module):
     def __init__(

--- a/ice_station_zebra/models/common/upconvblock.py
+++ b/ice_station_zebra/models/common/upconvblock.py
@@ -1,5 +1,6 @@
 import torch.nn as nn
 from torch import Tensor
+
 from .activations import get_activation
 
 

--- a/ice_station_zebra/models/common/upconvblock.py
+++ b/ice_station_zebra/models/common/upconvblock.py
@@ -1,6 +1,6 @@
+from typing import Type
 import torch.nn as nn
 from torch import Tensor
-from typing import Type
 
 class UpconvBlock(nn.Module):
     def __init__(

--- a/ice_station_zebra/models/common/upconvblock.py
+++ b/ice_station_zebra/models/common/upconvblock.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 import torch.nn as nn
 from torch import Tensor
 from .activations import get_activation

--- a/ice_station_zebra/models/common/upconvblock.py
+++ b/ice_station_zebra/models/common/upconvblock.py
@@ -3,10 +3,12 @@ from torch import Tensor
 from typing import Type
 
 class UpconvBlock(nn.Module):
-    def __init__(self, 
-                 in_channels: int, 
-                 out_channels: int, 
-                 activation: Type[nn.Module] = nn.ReLU,) -> None:
+    def __init__(
+        self, 
+        in_channels: int, 
+        out_channels: int, 
+        activation: Type[nn.Module] = nn.ReLU,
+    ) -> None:
         super().__init__()
 
         self.model = nn.Sequential(

--- a/ice_station_zebra/models/common/upconvblock.py
+++ b/ice_station_zebra/models/common/upconvblock.py
@@ -1,15 +1,18 @@
 import torch.nn as nn
 from torch import Tensor
-
+from typing import Type
 
 class UpconvBlock(nn.Module):
-    def __init__(self, in_channels: int, out_channels: int) -> None:
+    def __init__(self, 
+                 in_channels: int, 
+                 out_channels: int, 
+                 activation: Type[nn.Module] = nn.ReLU,) -> None:
         super().__init__()
 
         self.model = nn.Sequential(
             nn.Upsample(scale_factor=2, mode="nearest"),
             nn.Conv2d(in_channels, out_channels, kernel_size=2, padding="same"),
-            nn.ReLU(inplace=True),
+            activation(),
         )
 
     def forward(self, x: Tensor) -> Tensor:

--- a/ice_station_zebra/models/common/upconvblock.py
+++ b/ice_station_zebra/models/common/upconvblock.py
@@ -4,9 +4,9 @@ from torch import Tensor
 
 class UpconvBlock(nn.Module):
     def __init__(
-        self, 
-        in_channels: int, 
-        out_channels: int, 
+        self,
+        in_channels: int,
+        out_channels: int,
         activation: Type[nn.Module] = nn.ReLU,
     ) -> None:
         super().__init__()

--- a/ice_station_zebra/models/common/upconvblock.py
+++ b/ice_station_zebra/models/common/upconvblock.py
@@ -1,7 +1,7 @@
 import torch.nn as nn
 from torch import Tensor
 
-from .activations import get_activation
+from .activations import ACTIVATION_FROM_NAME
 
 
 class UpconvBlock(nn.Module):
@@ -13,13 +13,12 @@ class UpconvBlock(nn.Module):
     ) -> None:
         super().__init__()
 
-        def act():
-            return get_activation(activation)
+        activation_layer = ACTIVATION_FROM_NAME[activation]
 
         self.model = nn.Sequential(
             nn.Upsample(scale_factor=2, mode="nearest"),
             nn.Conv2d(in_channels, out_channels, kernel_size=2, padding="same"),
-            act(),
+            activation_layer(inplace=True),
         )
 
     def forward(self, x: Tensor) -> Tensor:

--- a/ice_station_zebra/models/common/upconvblock.py
+++ b/ice_station_zebra/models/common/upconvblock.py
@@ -1,6 +1,8 @@
 from typing import Type
+
 import torch.nn as nn
 from torch import Tensor
+
 
 class UpconvBlock(nn.Module):
     def __init__(

--- a/ice_station_zebra/models/common/upconvblock.py
+++ b/ice_station_zebra/models/common/upconvblock.py
@@ -2,6 +2,7 @@ from typing import Type
 
 import torch.nn as nn
 from torch import Tensor
+from .activations import get_activation
 
 
 class UpconvBlock(nn.Module):
@@ -9,14 +10,16 @@ class UpconvBlock(nn.Module):
         self,
         in_channels: int,
         out_channels: int,
-        activation: Type[nn.Module] = nn.ReLU,
+        activation: str = "ReLU",
     ) -> None:
         super().__init__()
+
+        act = lambda: get_activation(activation)
 
         self.model = nn.Sequential(
             nn.Upsample(scale_factor=2, mode="nearest"),
             nn.Conv2d(in_channels, out_channels, kernel_size=2, padding="same"),
-            activation(),
+            act(),
         )
 
     def forward(self, x: Tensor) -> Tensor:

--- a/ice_station_zebra/models/common/upconvblock.py
+++ b/ice_station_zebra/models/common/upconvblock.py
@@ -12,7 +12,8 @@ class UpconvBlock(nn.Module):
     ) -> None:
         super().__init__()
 
-        act = lambda: get_activation(activation)
+        def act():
+            return get_activation(activation)
 
         self.model = nn.Sequential(
             nn.Upsample(scale_factor=2, mode="nearest"),


### PR DESCRIPTION
Previously, activation functions were hardcoded in the blocks. 
Now they can be set via the configuration, allowing different models to use different activations without changing code.