### PR TITLE
Add non-trivial convolutional encoder/decoder

### DIFF
--- a/ice_station_zebra/config/model/encode_ddpm_decode.yaml
+++ b/ice_station_zebra/config/model/encode_ddpm_decode.yaml
@@ -8,7 +8,7 @@ latent_space:
   shape: [128, 128]
 
 encoder:
-  _target_: ice_station_zebra.models.encoders.NaiveLatentSpaceEncoder
+  _target_: ice_station_zebra.models.encoders.NaiveLinearEncoder
 
 processor:
   _target_: ice_station_zebra.models.processors.DDPMProcessor

--- a/ice_station_zebra/config/model/encode_ddpm_decode.yaml
+++ b/ice_station_zebra/config/model/encode_ddpm_decode.yaml
@@ -15,4 +15,4 @@ processor:
   timesteps: 1000 # DDPM timesteps
 
 decoder:
-  _target_: ice_station_zebra.models.decoders.NaiveLatentSpaceDecoder
+  _target_: ice_station_zebra.models.decoders.NaiveLinearDecoder

--- a/ice_station_zebra/config/model/encode_null_decode.yaml
+++ b/ice_station_zebra/config/model/encode_null_decode.yaml
@@ -14,4 +14,4 @@ processor:
   _target_: ice_station_zebra.models.processors.NullProcessor
 
 decoder:
-  _target_: ice_station_zebra.models.decoders.NaiveLatentSpaceDecoder
+  _target_: ice_station_zebra.models.decoders.NaiveLinearDecoder

--- a/ice_station_zebra/config/model/encode_null_decode.yaml
+++ b/ice_station_zebra/config/model/encode_null_decode.yaml
@@ -8,7 +8,7 @@ latent_space:
   shape: [32, 32]
 
 encoder:
-  _target_: ice_station_zebra.models.encoders.NaiveLatentSpaceEncoder
+  _target_: ice_station_zebra.models.encoders.NaiveLinearEncoder
 
 processor:
   _target_: ice_station_zebra.models.processors.NullProcessor

--- a/ice_station_zebra/config/model/encode_unet_decode.yaml
+++ b/ice_station_zebra/config/model/encode_unet_decode.yaml
@@ -16,4 +16,4 @@ processor:
   start_out_channels: 64 # Initial number of channels for the first convolutional layer
 
 decoder:
-  _target_: ice_station_zebra.models.decoders.NaiveLatentSpaceDecoder
+  _target_: ice_station_zebra.models.decoders.NaiveLinearDecoder

--- a/ice_station_zebra/config/model/encode_unet_decode.yaml
+++ b/ice_station_zebra/config/model/encode_unet_decode.yaml
@@ -8,7 +8,7 @@ latent_space:
   shape: [128, 128]
 
 encoder:
-  _target_: ice_station_zebra.models.encoders.NaiveLatentSpaceEncoder
+  _target_: ice_station_zebra.models.encoders.NaiveLinearEncoder
 
 processor:
   _target_: ice_station_zebra.models.processors.UNetProcessor

--- a/ice_station_zebra/models/common/__init__.py
+++ b/ice_station_zebra/models/common/__init__.py
@@ -1,4 +1,5 @@
 from .bottleneckblock import BottleneckBlock
+from .conv_block_downsample import ConvBlockDownsample
 from .convblock import ConvBlock
 from .resizing_average_pool_2d import ResizingAveragePool2d
 from .timeembed import TimeEmbed
@@ -7,6 +8,7 @@ from .upconvblock import UpconvBlock
 __all__ = [
     "BottleneckBlock",
     "ConvBlock",
+    "ConvBlockDownsample",
     "ResizingAveragePool2d",
     "TimeEmbed",
     "UpconvBlock",

--- a/ice_station_zebra/models/common/__init__.py
+++ b/ice_station_zebra/models/common/__init__.py
@@ -1,11 +1,13 @@
 from .bottleneckblock import BottleneckBlock
 from .convblock import ConvBlock
+from .resizing_average_pool_2d import ResizingAveragePool2d
 from .timeembed import TimeEmbed
 from .upconvblock import UpconvBlock
 
 __all__ = [
     "BottleneckBlock",
     "ConvBlock",
+    "ResizingAveragePool2d",
     "TimeEmbed",
     "UpconvBlock",
 ]

--- a/ice_station_zebra/models/common/__init__.py
+++ b/ice_station_zebra/models/common/__init__.py
@@ -1,5 +1,6 @@
 from .bottleneckblock import BottleneckBlock
 from .conv_block_downsample import ConvBlockDownsample
+from .conv_block_upsample import ConvBlockUpsample
 from .convblock import ConvBlock
 from .resizing_average_pool_2d import ResizingAveragePool2d
 from .timeembed import TimeEmbed
@@ -9,6 +10,7 @@ __all__ = [
     "BottleneckBlock",
     "ConvBlock",
     "ConvBlockDownsample",
+    "ConvBlockUpsample",
     "ResizingAveragePool2d",
     "TimeEmbed",
     "UpconvBlock",

--- a/ice_station_zebra/models/common/conv_block_downsample.py
+++ b/ice_station_zebra/models/common/conv_block_downsample.py
@@ -1,0 +1,38 @@
+from torch import nn
+
+from ice_station_zebra.types import TensorNCHW
+
+from .activations import ACTIVATION_FROM_NAME
+
+
+class ConvBlockDownsample(nn.Module):
+    """Convolutional block that halves the resolution and doubles the number of channels."""
+
+    def __init__(
+        self, n_input_channels: int, *, activation: str = "ReLU", kernel_size: int = 3
+    ) -> None:
+        """Initialize the ConvBlockDownsample module.
+
+        Args:
+            activation: the activation function to use.
+            kernel_size: the size of the convolutional kernel.
+            n_input_channels: the number of input channels.
+
+        """
+        super().__init__()
+        activation_layer = ACTIVATION_FROM_NAME[activation]
+        self.n_output_channels = 2 * n_input_channels
+        self.model = nn.Sequential(
+            nn.Conv2d(
+                n_input_channels,
+                self.n_output_channels,
+                kernel_size=kernel_size,
+                stride=2,
+                padding=(kernel_size - 1) // 2,
+            ),
+            nn.BatchNorm2d(self.n_output_channels),
+            activation_layer(inplace=True),
+        )
+
+    def forward(self, x: TensorNCHW) -> TensorNCHW:
+        return self.model(x)

--- a/ice_station_zebra/models/common/conv_block_upsample.py
+++ b/ice_station_zebra/models/common/conv_block_upsample.py
@@ -5,16 +5,16 @@ from ice_station_zebra.types import TensorNCHW
 from .activations import ACTIVATION_FROM_NAME
 
 
-class ConvBlockDownsample(nn.Module):
-    """Convolutional block that halves the resolution and doubles the number of channels.
+class ConvBlockUpsample(nn.Module):
+    """Convolutional block that doubles the resolution and halves the number of channels.
 
-    This is the reverse of ConvBlockUpsample.
+    This is the reverse of ConvBlockDownsample.
     """
 
     def __init__(
         self, n_input_channels: int, *, activation: str = "ReLU", kernel_size: int = 3
     ) -> None:
-        """Initialize the ConvBlockDownsample module.
+        """Initialize the ConvBlockUpsample module.
 
         Args:
             activation: the activation function to use.
@@ -26,14 +26,16 @@ class ConvBlockDownsample(nn.Module):
         activation_layer = ACTIVATION_FROM_NAME[activation]
 
         # Calculate convolutional parameters
-        n_output_channels = n_input_channels * 2
+        n_output_channels = n_input_channels // 2
         padding = (kernel_size - 1) // 2
+        output_padding = kernel_size % 2
 
         self.model = nn.Sequential(
-            nn.Conv2d(
+            nn.ConvTranspose2d(
                 n_input_channels,
                 n_output_channels,
                 kernel_size=kernel_size,
+                output_padding=output_padding,
                 padding=padding,
                 stride=2,
             ),

--- a/ice_station_zebra/models/common/resizing_average_pool_2d.py
+++ b/ice_station_zebra/models/common/resizing_average_pool_2d.py
@@ -1,4 +1,5 @@
-import math
+from collections.abc import Sequence
+from math import ceil
 
 from torch import nn
 
@@ -12,9 +13,7 @@ class ResizingAveragePool2d(nn.Module):
     The input and output sizes must be specified at initialisation time.
     """
 
-    def __init__(
-        self, input_size: tuple[int, int], output_size: tuple[int, int]
-    ) -> None:
+    def __init__(self, input_size: Sequence[int], output_size: Sequence[int]) -> None:
         """Initialize the ResizingAveragePool2d module.
 
         Args:
@@ -25,25 +24,24 @@ class ResizingAveragePool2d(nn.Module):
         super().__init__()
 
         # Calculate an upsampling factor that will leave the input larger than the output
-        upsample_scale = math.ceil(
-            max(
-                [
-                    size_out / size_in
-                    for size_in, size_out in zip(input_size, output_size, strict=True)
-                ]
-                + [1]
-            )
+        upsample_scale = max(
+            [
+                ceil(size_out / size_in)
+                for size_in, size_out in zip(input_size, output_size, strict=True)
+            ]
+            + [1]
         )
 
         # We may have different stride/kernel sizes in the H and W dimensions
         # These values will ensure that the output is the correct size
-        strides = [
-            input_size[idx] * upsample_scale // output_size[idx] for idx in range(2)
-        ]
-        kernel_sizes = [
-            input_size[idx] * upsample_scale - (output_size[idx] - 1) * strides[idx]
-            for idx in range(2)
-        ]
+        strides = (
+            input_size[0] * upsample_scale // output_size[0],
+            input_size[1] * upsample_scale // output_size[1],
+        )
+        kernel_sizes = (
+            input_size[0] * upsample_scale - (output_size[0] - 1) * strides[0],
+            input_size[1] * upsample_scale - (output_size[1] - 1) * strides[1],
+        )
 
         # We upsample and then pool down to the desired output size
         self.model = nn.Sequential(

--- a/ice_station_zebra/models/common/resizing_average_pool_2d.py
+++ b/ice_station_zebra/models/common/resizing_average_pool_2d.py
@@ -1,0 +1,55 @@
+import math
+
+from torch import nn
+
+from ice_station_zebra.types import TensorNCHW
+
+
+class ResizingAveragePool2d(nn.Module):
+    """Resize to an arbitrary output shape using average pooling.
+
+    This performs an upscaling and then downsamples using average pooling.
+    The input and output sizes must be specified at initialisation time.
+    """
+
+    def __init__(
+        self, input_size: tuple[int, int], output_size: tuple[int, int]
+    ) -> None:
+        """Initialize the ResizingAveragePool2d module.
+
+        Args:
+            input_size: the target input size in H x W format.
+            output_size: the target output size in H x W format.
+
+        """
+        super().__init__()
+
+        # Calculate an upsampling factor that will leave the input larger than the output
+        upsample_scale = math.ceil(
+            max(
+                [
+                    size_out / size_in
+                    for size_in, size_out in zip(input_size, output_size, strict=True)
+                ]
+                + [1]
+            )
+        )
+
+        # We may have different stride/kernel sizes in the H and W dimensions
+        # These values will ensure that the output is the correct size
+        strides = [
+            input_size[idx] * upsample_scale // output_size[idx] for idx in range(2)
+        ]
+        kernel_sizes = [
+            input_size[idx] * upsample_scale - (output_size[idx] - 1) * strides[idx]
+            for idx in range(2)
+        ]
+
+        # We upsample and then pool down to the desired output size
+        self.model = nn.Sequential(
+            nn.Upsample(scale_factor=upsample_scale),
+            nn.AvgPool2d(kernel_size=kernel_sizes, stride=strides, padding=0),
+        )
+
+    def forward(self, x: TensorNCHW) -> TensorNCHW:
+        return self.model(x)

--- a/ice_station_zebra/models/decoders/__init__.py
+++ b/ice_station_zebra/models/decoders/__init__.py
@@ -1,9 +1,9 @@
 from .base_decoder import BaseDecoder
 from .cnn_decoder import CNNDecoder
-from .naive_latent_space_decoder import NaiveLatentSpaceDecoder
+from .naive_linear_decoder import NaiveLinearDecoder
 
 __all__ = [
     "BaseDecoder",
     "CNNDecoder",
-    "NaiveLatentSpaceDecoder",
+    "NaiveLinearDecoder",
 ]

--- a/ice_station_zebra/models/decoders/__init__.py
+++ b/ice_station_zebra/models/decoders/__init__.py
@@ -1,7 +1,9 @@
 from .base_decoder import BaseDecoder
+from .cnn_decoder import CNNDecoder
 from .naive_latent_space_decoder import NaiveLatentSpaceDecoder
 
 __all__ = [
     "BaseDecoder",
+    "CNNDecoder",
     "NaiveLatentSpaceDecoder",
 ]

--- a/ice_station_zebra/models/decoders/base_decoder.py
+++ b/ice_station_zebra/models/decoders/base_decoder.py
@@ -42,7 +42,7 @@ class BaseDecoder(nn.Module):
         )
 
     def rollout(self, x: TensorNCHW) -> TensorNCHW:
-        """Single rollout step: process in NCHW latent space.
+        """Single rollout step: decode NCHW latent data into NCHW output.
 
         Args:
             x: TensorNCHW with (batch_size, n_latent_channels_total, latent_height, latent_width)

--- a/ice_station_zebra/models/decoders/cnn_decoder.py
+++ b/ice_station_zebra/models/decoders/cnn_decoder.py
@@ -50,7 +50,7 @@ class CNNDecoder(BaseDecoder):
         self.model = nn.Sequential(*layers)
 
     def rollout(self, x: TensorNCHW) -> TensorNCHW:
-        """Apply CNNDecoder to NCHW tensor.
+        """Single rollout step: decode NCHW latent data into NCHW output.
 
         Args:
             x: TensorNCHW with (batch_size, input_channels, input_height, input_width)

--- a/ice_station_zebra/models/decoders/cnn_decoder.py
+++ b/ice_station_zebra/models/decoders/cnn_decoder.py
@@ -1,0 +1,62 @@
+from typing import Any
+
+from torch import nn
+
+from ice_station_zebra.models.common import ConvBlockUpsample, ResizingAveragePool2d
+from ice_station_zebra.types import DataSpace, TensorNCHW
+
+from .base_decoder import BaseDecoder
+
+
+class CNNDecoder(BaseDecoder):
+    """Decoder that uses a convolutional neural net (CNN) to translate latent space back to data space.
+
+    Input space:
+        TensorNTCHW with (batch_size, n_history_steps, input_channels, input_height, input_width)
+
+    Latent space:
+        TensorNTCHW with (batch_size, n_history_steps, latent_channels, latent_height, latent_width)
+    """
+
+    def __init__(
+        self,
+        *,
+        latent_space: DataSpace,
+        output_space: DataSpace,
+        n_layers: int = 4,
+        activation: str = "ReLU",
+        **kwargs: Any,
+    ) -> None:
+        """Initialise a CNNDecoder."""
+        super().__init__(**kwargs)
+
+        # Construct list of layers
+        layers: list[nn.Module] = []
+
+        # Add n_layers size-increasing convolutional blocks
+        n_channels = self.n_latent_channels_total
+        for _ in range(n_layers):
+            layers.append(ConvBlockUpsample(n_channels, activation=activation))
+            n_channels //= 2
+
+        # Add an adaptive pooling layer that sets the final spatial dimensions
+        final_conv_shape = [size * (2**n_layers) for size in latent_space.shape]
+        layers.append(ResizingAveragePool2d(final_conv_shape, output_space.shape))
+
+        # Convolve to the desired number of latent channels
+        layers.append(nn.Conv2d(n_channels, output_space.channels, 1))
+
+        # Combine the layers sequentially
+        self.model = nn.Sequential(*layers)
+
+    def rollout(self, x: TensorNCHW) -> TensorNCHW:
+        """Apply CNNDecoder to NCHW tensor.
+
+        Args:
+            x: TensorNCHW with (batch_size, input_channels, input_height, input_width)
+
+        Returns:
+            TensorNCHW with (batch_size, latent_channels, latent_height, latent_width)
+
+        """
+        return self.model(x)

--- a/ice_station_zebra/models/decoders/naive_linear_decoder.py
+++ b/ice_station_zebra/models/decoders/naive_linear_decoder.py
@@ -1,4 +1,3 @@
-import math
 from typing import Any
 
 from torch import nn
@@ -8,7 +7,7 @@ from ice_station_zebra.types import DataSpace, TensorNCHW
 from .base_decoder import BaseDecoder
 
 
-class NaiveLatentSpaceDecoder(BaseDecoder):
+class NaiveLinearDecoder(BaseDecoder):
     """Naive, linear decoder that takes data in a latent space and translates it to a larger output space.
 
     Latent space:
@@ -19,38 +18,29 @@ class NaiveLatentSpaceDecoder(BaseDecoder):
     """
 
     def __init__(
-        self, *, latent_space: DataSpace, output_space: DataSpace, **kwargs: Any
+        self,
+        *,
+        latent_space: DataSpace,  # noqa: ARG002
+        output_space: DataSpace,
+        **kwargs: Any,
     ) -> None:
-        """Initialise a NaiveLatentSpaceDecoder."""
+        """Initialise a NaiveLinearDecoder."""
         super().__init__(**kwargs)
 
         # List of layers
         layers: list[nn.Module] = []
 
-        # Add size-increasing convolutional layers until we are larger than the output shape
-        n_conv_layers = math.floor(
-            math.log2(min(*output_space.shape) / max(*latent_space.shape))
-        )
-        n_channels = self.n_latent_channels_total
-        for _ in range(n_conv_layers):
-            layers.append(
-                nn.ConvTranspose2d(
-                    n_channels, n_channels // 2, kernel_size=4, stride=2, padding=1
-                )
-            )
-            n_channels //= 2
+        # Convolve to the desired number of output channels
+        layers.append(nn.Conv2d(self.n_latent_channels_total, output_space.channels, 1))
 
         # Resample to the desired output shape
         layers.append(nn.Upsample(output_space.shape))
-
-        # Convolve to the desired number of output channels
-        layers.append(nn.Conv2d(n_channels, output_space.channels, 1))
 
         # Combine the layers sequentially
         self.model = nn.Sequential(*layers)
 
     def rollout(self, x: TensorNCHW) -> TensorNCHW:
-        """Forward step: decode latent space into output space.
+        """Single rollout step: decode NCHW latent data into NCHW output.
 
         Args:
             x: TensorNCHW with (batch_size, n_latent_channels_total, latent_height, latent_width)

--- a/ice_station_zebra/models/encoders/__init__.py
+++ b/ice_station_zebra/models/encoders/__init__.py
@@ -1,7 +1,9 @@
 from .base_encoder import BaseEncoder
+from .cnn_encoder import CNNEncoder
 from .naive_latent_space_encoder import NaiveLatentSpaceEncoder
 
 __all__ = [
     "BaseEncoder",
+    "CNNEncoder",
     "NaiveLatentSpaceEncoder",
 ]

--- a/ice_station_zebra/models/encoders/__init__.py
+++ b/ice_station_zebra/models/encoders/__init__.py
@@ -1,9 +1,9 @@
 from .base_encoder import BaseEncoder
 from .cnn_encoder import CNNEncoder
-from .naive_latent_space_encoder import NaiveLatentSpaceEncoder
+from .naive_linear_encoder import NaiveLinearEncoder
 
 __all__ = [
     "BaseEncoder",
     "CNNEncoder",
-    "NaiveLatentSpaceEncoder",
+    "NaiveLinearEncoder",
 ]

--- a/ice_station_zebra/models/encoders/base_encoder.py
+++ b/ice_station_zebra/models/encoders/base_encoder.py
@@ -42,7 +42,7 @@ class BaseEncoder(nn.Module):
         )
 
     def rollout(self, x: TensorNCHW) -> TensorNCHW:
-        """Single rollout step: process in NCHW latent space.
+        """Single rollout step: encode NCHW input into NCHW latent space.
 
         Args:
             x: TensorNCHW with (batch_size, input_channels, input_height, input_width)

--- a/ice_station_zebra/models/encoders/cnn_encoder.py
+++ b/ice_station_zebra/models/encoders/cnn_encoder.py
@@ -1,0 +1,62 @@
+from typing import Any
+
+from torch import nn
+
+from ice_station_zebra.models.common import ConvBlockDownsample, ResizingAveragePool2d
+from ice_station_zebra.types import DataSpace, TensorNCHW
+
+from .base_encoder import BaseEncoder
+
+
+class CNNEncoder(BaseEncoder):
+    """Encoder that uses a convolutional neural net (CNN) to translate data to a latent space.
+
+    Input space:
+        TensorNTCHW with (batch_size, n_history_steps, input_channels, input_height, input_width)
+
+    Latent space:
+        TensorNTCHW with (batch_size, n_history_steps, latent_channels, latent_height, latent_width)
+    """
+
+    def __init__(
+        self,
+        *,
+        input_space: DataSpace,
+        latent_space: DataSpace,
+        n_layers: int = 4,
+        activation: str = "ReLU",
+        **kwargs: Any,
+    ) -> None:
+        """Initialise a CNNEncoder."""
+        super().__init__(name=input_space.name, **kwargs)
+
+        # Construct list of layers
+        layers: list[nn.Module] = []
+
+        # Start with an adaptive pooling layer that sets the initial spatial dimensions
+        initial_conv_shape = [size * (2**n_layers) for size in latent_space.shape]
+        layers.append(ResizingAveragePool2d(input_space.shape, initial_conv_shape))
+
+        # Add n_layers size-reducing convolutional blocks
+        n_channels = input_space.channels
+        for _ in range(n_layers):
+            layers.append(ConvBlockDownsample(n_channels, activation=activation))
+            n_channels *= 2
+
+        # Convolve to the desired number of latent channels
+        layers.append(nn.Conv2d(n_channels, latent_space.channels, 1))
+
+        # Combine the layers sequentially
+        self.model = nn.Sequential(*layers)
+
+    def rollout(self, x: TensorNCHW) -> TensorNCHW:
+        """Apply CNNEncoder to NCHW tensor.
+
+        Args:
+            x: TensorNCHW with (batch_size, input_channels, input_height, input_width)
+
+        Returns:
+            TensorNCHW with (batch_size, latent_channels, latent_height, latent_width)
+
+        """
+        return self.model(x)

--- a/ice_station_zebra/models/encoders/cnn_encoder.py
+++ b/ice_station_zebra/models/encoders/cnn_encoder.py
@@ -50,7 +50,7 @@ class CNNEncoder(BaseEncoder):
         self.model = nn.Sequential(*layers)
 
     def rollout(self, x: TensorNCHW) -> TensorNCHW:
-        """Apply CNNEncoder to NCHW tensor.
+        """Single rollout step: encode NCHW input into NCHW latent space.
 
         Args:
             x: TensorNCHW with (batch_size, input_channels, input_height, input_width)

--- a/ice_station_zebra/models/encoders/cnn_encoder.py
+++ b/ice_station_zebra/models/encoders/cnn_encoder.py
@@ -11,6 +11,8 @@ from .base_encoder import BaseEncoder
 class CNNEncoder(BaseEncoder):
     """Encoder that uses a convolutional neural net (CNN) to translate data to a latent space.
 
+    The layers are the reverse of those in the CNNDecoder.
+
     Input space:
         TensorNTCHW with (batch_size, n_history_steps, input_channels, input_height, input_width)
 

--- a/ice_station_zebra/models/encoders/naive_linear_encoder.py
+++ b/ice_station_zebra/models/encoders/naive_linear_encoder.py
@@ -1,4 +1,3 @@
-import math
 from typing import Any
 
 from torch import nn
@@ -8,7 +7,7 @@ from ice_station_zebra.types import DataSpace, TensorNCHW
 from .base_encoder import BaseEncoder
 
 
-class NaiveLatentSpaceEncoder(BaseEncoder):
+class NaiveLinearEncoder(BaseEncoder):
     """Naive, linear encoder that takes data in an input space and translates it to a smaller latent space.
 
     Input space:
@@ -21,38 +20,23 @@ class NaiveLatentSpaceEncoder(BaseEncoder):
     def __init__(
         self, *, input_space: DataSpace, latent_space: DataSpace, **kwargs: Any
     ) -> None:
-        """Initialise a NaiveLatentSpaceEncoder."""
+        """Initialise a NaiveLinearEncoder."""
         super().__init__(name=input_space.name, **kwargs)
 
         # Construct list of layers
         layers: list[nn.Module] = []
 
-        # Calculate how many size-reducing convolutional layers are needed
-        n_conv_layers = math.floor(
-            math.log2(min(*input_space.shape) / max(*latent_space.shape))
-        )
-
-        # Add size-reducing convolutional layers
-        n_channels = input_space.channels
-        for _ in range(n_conv_layers):
-            layers.append(
-                nn.Conv2d(
-                    n_channels, 2 * n_channels, kernel_size=4, stride=2, padding=1
-                )
-            )
-            n_channels *= 2
-
         # Resample to the desired latent shape
         layers.append(nn.Upsample(latent_space.shape))
 
         # Convolve to the desired number of latent channels
-        layers.append(nn.Conv2d(n_channels, latent_space.channels, 1))
+        layers.append(nn.Conv2d(input_space.channels, latent_space.channels, 1))
 
         # Combine the layers sequentially
         self.model = nn.Sequential(*layers)
 
     def rollout(self, x: TensorNCHW) -> TensorNCHW:
-        """Apply NaiveLatentSpaceEncoder to NCHW tensor.
+        """Single rollout step: encode NCHW input into NCHW latent space.
 
         Args:
             x: TensorNCHW with (batch_size, input_channels, input_height, input_width)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from ice_station_zebra.types import AnemoiCreateArgs
 def cfg_decoder() -> DictConfig:
     """Test configuration for a decoder."""
     return DictConfig(
-        {"_target_": "ice_station_zebra.models.decoders.NaiveLatentSpaceDecoder"}
+        {"_target_": "ice_station_zebra.models.decoders.NaiveLinearDecoder"}
     )
 
 
@@ -22,7 +22,7 @@ def cfg_decoder() -> DictConfig:
 def cfg_encoder() -> DictConfig:
     """Test configuration for an encoder."""
     return DictConfig(
-        {"_target_": "ice_station_zebra.models.encoders.NaiveLatentSpaceEncoder"}
+        {"_target_": "ice_station_zebra.models.encoders.NaiveLinearEncoder"}
     )
 
 

--- a/tests/models/test_decoders.py
+++ b/tests/models/test_decoders.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from ice_station_zebra.models.decoders import NaiveLatentSpaceDecoder
+from ice_station_zebra.models.decoders import NaiveLinearDecoder
 from ice_station_zebra.types import DataSpace
 
 
@@ -9,7 +9,7 @@ from ice_station_zebra.types import DataSpace
 @pytest.mark.parametrize("test_output_shape", [(512, 512, 4), (1000, 200, 1)])
 @pytest.mark.parametrize("test_batch_size", [1, 2, 5])
 @pytest.mark.parametrize("test_n_forecast_steps", [1, 3, 5])
-class TestNaiveLatentSpaceDecoder:
+class TestNaiveLinearDecoder:
     def test_forward_shape(
         self,
         test_batch_size: int,
@@ -23,7 +23,7 @@ class TestNaiveLatentSpaceDecoder:
         output_space = DataSpace(
             name="output", shape=test_output_shape[0:2], channels=test_output_shape[2]
         )
-        decoder = NaiveLatentSpaceDecoder(
+        decoder = NaiveLinearDecoder(
             latent_space=latent_space,
             n_forecast_steps=test_n_forecast_steps,
             n_latent_channels_total=latent_space.channels,

--- a/tests/models/test_encoders.py
+++ b/tests/models/test_encoders.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from ice_station_zebra.models.encoders import NaiveLatentSpaceEncoder
+from ice_station_zebra.models.encoders import NaiveLinearEncoder
 from ice_station_zebra.types import DataSpace
 
 
@@ -9,7 +9,7 @@ from ice_station_zebra.types import DataSpace
 @pytest.mark.parametrize("test_latent_shape", [(32, 32, 128), (100, 200, 3)])
 @pytest.mark.parametrize("test_batch_size", [1, 2, 5])
 @pytest.mark.parametrize("test_n_history_steps", [1, 3, 5])
-class TestNaiveLatentSpaceEncoder:
+class TestNaiveLinearEncoder:
     def test_forward_shape(
         self,
         test_batch_size: int,
@@ -23,7 +23,7 @@ class TestNaiveLatentSpaceEncoder:
         latent_space = DataSpace(
             name="latent", shape=test_latent_shape[0:2], channels=test_latent_shape[2]
         )
-        encoder = NaiveLatentSpaceEncoder(
+        encoder = NaiveLinearEncoder(
             input_space=input_space,
             latent_space=latent_space,
             n_history_steps=test_n_history_steps,


### PR DESCRIPTION
- Further simplify the naive linear encoder/decoder
- Add a non-linear CNN with activation functions

## Testing

`naive-null-naive`: 781 params

<details>

```
  | Name      | Type               | Params | Mode
---------------------------------------------------------
0 | encoder_0 | NaiveLinearEncoder | 700    | train
1 | encoder_1 | NaiveLinearEncoder | 40     | train
2 | processor | NullProcessor      | 0      | train
3 | decoder   | NaiveLinearDecoder | 41     | train
---------------------------------------------------------
781       Trainable params
0         Non-trainable params
781       Total params
0.003     Total estimated model params size (MB)
14        Modules in train mode
0         Modules in eval mode
https://wandb.ai/turing-seaice/leaderboard/runs/7vbx9za4
```
</details>

`cnn-null-cnn`: 1.8M params
<details>

```
  | Name      | Type          | Params | Mode
----------------------------------------------------
0 | encoder_0 | CNNEncoder    | 1.8 M  | train
1 | encoder_1 | CNNEncoder    | 2.0 K  | train
2 | processor | NullProcessor | 0      | train
3 | decoder   | CNNDecoder    | 2.2 K  | train
----------------------------------------------------
1.8 M     Trainable params
0         Non-trainable params
1.8 M     Total params
7.147     Total estimated model params size (MB)
83        Modules in train mode
0         Modules in eval mode
https://wandb.ai/turing-seaice/leaderboard/runs/i4fnfakn
```
</details>

`naive-unet-naive`: 11M params
<details>

```
  | Name      | Type               | Params | Mode
---------------------------------------------------------
0 | encoder_0 | NaiveLinearEncoder | 700    | train
1 | encoder_1 | NaiveLinearEncoder | 40     | train
2 | processor | UNetProcessor      | 11.0 M | train
3 | decoder   | NaiveLinearDecoder | 41     | train
---------------------------------------------------------
11.0 M    Trainable params
0         Non-trainable params
11.0 M    Total params
43.901    Total estimated model params size (MB)
102       Modules in train mode
0         Modules in eval mode
https://wandb.ai/turing-seaice/leaderboard/runs/aizqh771
```
</details>

`cnn-unet-cnn`: 12.8M params
<details>

```
  | Name      | Type          | Params | Mode
----------------------------------------------------
0 | encoder_0 | CNNEncoder    | 1.8 M  | train
1 | encoder_1 | CNNEncoder    | 2.0 K  | train
2 | processor | UNetProcessor | 11.0 M | train
3 | decoder   | CNNDecoder    | 2.2 K  | train
----------------------------------------------------
12.8 M    Trainable params
0         Non-trainable params
12.8 M    Total params
51.045    Total estimated model params size (MB)
171       Modules in train mode
0         Modules in eval mode
```
</details>
