### PR TITLE
Make target tensor available to processors

### DIFF
--- a/ice_station_zebra/models/decoders/base_decoder.py
+++ b/ice_station_zebra/models/decoders/base_decoder.py
@@ -36,7 +36,7 @@ class BaseDecoder(nn.Module):
             TensorNCHW with (batch_size, output_channels, output_height, output_width)
 
         """
-        msg = "If you are using the default forward method, you must implement rollout."
+        msg = "If you are using the default rollout method, you must implement forward."
         raise NotImplementedError(msg)
 
     def rollout(self, x: TensorNTCHW) -> TensorNTCHW:

--- a/ice_station_zebra/models/decoders/base_decoder.py
+++ b/ice_station_zebra/models/decoders/base_decoder.py
@@ -26,10 +26,23 @@ class BaseDecoder(nn.Module):
         self.data_space_out = data_space_out
         self.n_forecast_steps = n_forecast_steps
 
-    def forward(self, x: TensorNTCHW) -> TensorNTCHW:
-        """Forward step: decode latent space into output space.
+    def forward(self, x: TensorNCHW) -> TensorNCHW:
+        """Forward process. Decode latent space into output space for a single timestep.
 
-        The default implementation simply calls `self.rollout` independently on each
+        Args:
+            x: TensorNCHW with (batch_size, n_latent_channels_total, latent_height, latent_width)
+
+        Returns:
+            TensorNCHW with (batch_size, output_channels, output_height, output_width)
+
+        """
+        msg = "If you are using the default forward method, you must implement rollout."
+        raise NotImplementedError(msg)
+
+    def rollout(self, x: TensorNTCHW) -> TensorNTCHW:
+        """Rollout multiple forward steps: decoding latent space into output space.
+
+        The default implementation simply calls `self.forward` independently on each
         time slice. These are then stacked together to produce the final output.
 
         Args:
@@ -41,22 +54,9 @@ class BaseDecoder(nn.Module):
         """
         return stack(
             [
-                # Apply rollout to each NCHW slice in the NTCHW input
-                self.rollout(x[:, idx_t, :, :, :])
+                # Rollout the model over the input slices, producing an output for each one.
+                self.forward(x[:, idx_t, :, :, :])
                 for idx_t in range(self.n_forecast_steps)
             ],
             dim=1,
         )
-
-    def rollout(self, x: TensorNCHW) -> TensorNCHW:
-        """Single rollout step: decode NCHW latent data into NCHW output.
-
-        Args:
-            x: TensorNCHW with (batch_size, n_latent_channels_total, latent_height, latent_width)
-
-        Returns:
-            TensorNCHW with (batch_size, output_channels, output_height, output_width)
-
-        """
-        msg = "If you are using the default forward method, you must implement rollout."
-        raise NotImplementedError(msg)

--- a/ice_station_zebra/models/decoders/base_decoder.py
+++ b/ice_station_zebra/models/decoders/base_decoder.py
@@ -27,7 +27,7 @@ class BaseDecoder(nn.Module):
         self.n_forecast_steps = n_forecast_steps
 
     def forward(self, x: TensorNCHW) -> TensorNCHW:
-        """Forward process. Decode latent space into output space for a single timestep.
+        """Forward step: decode latent space into output space for a single timestep.
 
         Args:
             x: TensorNCHW with (batch_size, n_latent_channels_total, latent_height, latent_width)
@@ -40,7 +40,7 @@ class BaseDecoder(nn.Module):
         raise NotImplementedError(msg)
 
     def rollout(self, x: TensorNTCHW) -> TensorNTCHW:
-        """Rollout multiple forward steps: decoding latent space into output space.
+        """Decode latent space into output space across multiple timesteps.
 
         The default implementation simply calls `self.forward` independently on each
         time slice. These are then stacked together to produce the final output.

--- a/ice_station_zebra/models/decoders/cnn_decoder.py
+++ b/ice_station_zebra/models/decoders/cnn_decoder.py
@@ -65,8 +65,8 @@ class CNNDecoder(BaseDecoder):
         # Combine the layers sequentially
         self.model = nn.Sequential(*layers)
 
-    def rollout(self, x: TensorNCHW) -> TensorNCHW:
-        """Single rollout step: decode NCHW latent data into NCHW output.
+    def forward(self, x: TensorNCHW) -> TensorNCHW:
+        """Forward process. Decode latent space into output space for a single timestep.
 
         Args:
             x: TensorNCHW with (batch_size, input_channels, input_height, input_width)

--- a/ice_station_zebra/models/decoders/cnn_decoder.py
+++ b/ice_station_zebra/models/decoders/cnn_decoder.py
@@ -66,7 +66,7 @@ class CNNDecoder(BaseDecoder):
         self.model = nn.Sequential(*layers)
 
     def forward(self, x: TensorNCHW) -> TensorNCHW:
-        """Forward process. Decode latent space into output space for a single timestep.
+        """Forward step: decode latent space into output space with a CNN.
 
         Args:
             x: TensorNCHW with (batch_size, input_channels, input_height, input_width)

--- a/ice_station_zebra/models/decoders/naive_linear_decoder.py
+++ b/ice_station_zebra/models/decoders/naive_linear_decoder.py
@@ -37,7 +37,7 @@ class NaiveLinearDecoder(BaseDecoder):
         self.model = nn.Sequential(*layers)
 
     def forward(self, x: TensorNCHW) -> TensorNCHW:
-        """Forward process. Decode latent space into output space for a single timestep.
+        """Forward step: decode latent space into output space with a linear transform.
 
         Args:
             x: TensorNCHW with (batch_size, n_latent_channels_total, latent_height, latent_width)

--- a/ice_station_zebra/models/decoders/naive_linear_decoder.py
+++ b/ice_station_zebra/models/decoders/naive_linear_decoder.py
@@ -36,8 +36,8 @@ class NaiveLinearDecoder(BaseDecoder):
         # Combine the layers sequentially
         self.model = nn.Sequential(*layers)
 
-    def rollout(self, x: TensorNCHW) -> TensorNCHW:
-        """Single rollout step: decode NCHW latent data into NCHW output.
+    def forward(self, x: TensorNCHW) -> TensorNCHW:
+        """Forward process. Decode latent space into output space for a single timestep.
 
         Args:
             x: TensorNCHW with (batch_size, n_latent_channels_total, latent_height, latent_width)

--- a/ice_station_zebra/models/encode_process_decode.py
+++ b/ice_station_zebra/models/encode_process_decode.py
@@ -87,9 +87,11 @@ class EncodeProcessDecode(ZebraModel):
         latent_input_combined: TensorNTCHW = torch.cat(latent_inputs, dim=2)
 
         # Process in latent space:
-        # input tensor with (batch_size, n_history_steps, n_latent_channels_total, latent_height, latent_width)
-        # output tensor with (batch_size, n_forecast_steps, n_latent_channels_total, latent_height, latent_width)
-        latent_output: TensorNTCHW = self.processor.rollout(latent_input_combined)
+        # combined input tensor with (batch_size, n_history_steps, n_latent_channels_total, latent_height, latent_width)
+        # target tensor with (batch_size, n_forecast_steps, n_latent_channels_total, latent_height, latent_width) or None
+        latent_output: TensorNTCHW = self.processor.rollout(
+            latent_input_combined, inputs.get("target")
+        )
 
         # Decode to output space: tensor with (batch_size, n_forecast_steps, n_output_channels, output_height, output_width)
         output: TensorNTCHW = self.decoder.rollout(latent_output)

--- a/ice_station_zebra/models/encode_process_decode.py
+++ b/ice_station_zebra/models/encode_process_decode.py
@@ -80,17 +80,19 @@ class EncodeProcessDecode(ZebraModel):
         """
         # Encode inputs into latent space: list of tensors with (batch_size, n_history_steps, n_latent_channels, latent_height, latent_width)
         latent_inputs: list[TensorNTCHW] = [
-            encoder(inputs[encoder.name]) for encoder in self.encoders
+            encoder.rollout(inputs[encoder.name]) for encoder in self.encoders
         ]
 
         # Combine in the variable dimension: tensor with (batch_size, n_history_steps, n_latent_channels_total, latent_height, latent_width)
         latent_input_combined: TensorNTCHW = torch.cat(latent_inputs, dim=2)
 
-        # Process in latent space: tensor with (batch_size, n_forecast_steps, n_latent_channels_total, latent_height, latent_width)
-        latent_output: TensorNTCHW = self.processor(latent_input_combined)
+        # Process in latent space:
+        # input tensor with (batch_size, n_history_steps, n_latent_channels_total, latent_height, latent_width)
+        # output tensor with (batch_size, n_forecast_steps, n_latent_channels_total, latent_height, latent_width)
+        latent_output: TensorNTCHW = self.processor.rollout(latent_input_combined)
 
         # Decode to output space: tensor with (batch_size, n_forecast_steps, n_output_channels, output_height, output_width)
-        output: TensorNTCHW = self.decoder(latent_output)
+        output: TensorNTCHW = self.decoder.rollout(latent_output)
 
         # Return
         return output

--- a/ice_station_zebra/models/encoders/base_encoder.py
+++ b/ice_station_zebra/models/encoders/base_encoder.py
@@ -41,7 +41,7 @@ class BaseEncoder(nn.Module):
             TensorNCHW with (batch_size, latent_channels, latent_height, latent_width)
 
         """
-        msg = "If you are using the default forward method, you must implement rollout."
+        msg = "If you are using the default rollout method, you must implement forward."
         raise NotImplementedError(msg)
 
     def rollout(self, x: TensorNTCHW) -> TensorNTCHW:

--- a/ice_station_zebra/models/encoders/base_encoder.py
+++ b/ice_station_zebra/models/encoders/base_encoder.py
@@ -32,7 +32,7 @@ class BaseEncoder(nn.Module):
         self.n_history_steps = n_history_steps
 
     def forward(self, x: TensorNCHW) -> TensorNCHW:
-        """Forward process. Encode input space into latent space for a single timestep.
+        """Forward step: encode input space into latent space for a single timestep.
 
         Args:
             x: TensorNCHW with (batch_size, input_channels, input_height, input_width)
@@ -45,7 +45,7 @@ class BaseEncoder(nn.Module):
         raise NotImplementedError(msg)
 
     def rollout(self, x: TensorNTCHW) -> TensorNTCHW:
-        """Rollout multiple forward steps: encoding input space into latent space.
+        """Encode input space into latent space across multiple timesteps.
 
         The default implementation simply calls `self.forward` independently on each
         time slice. These are then stacked together to produce the final output.

--- a/ice_station_zebra/models/encoders/base_encoder.py
+++ b/ice_station_zebra/models/encoders/base_encoder.py
@@ -31,10 +31,23 @@ class BaseEncoder(nn.Module):
         self.name = data_space_in.name
         self.n_history_steps = n_history_steps
 
-    def forward(self, x: TensorNTCHW) -> TensorNTCHW:
-        """Forward step: encode input space into latent space.
+    def forward(self, x: TensorNCHW) -> TensorNCHW:
+        """Forward process. Encode input space into latent space for a single timestep.
 
-        The default implementation simply calls `self.rollout` independently on each
+        Args:
+            x: TensorNCHW with (batch_size, input_channels, input_height, input_width)
+
+        Returns:
+            TensorNCHW with (batch_size, latent_channels, latent_height, latent_width)
+
+        """
+        msg = "If you are using the default forward method, you must implement rollout."
+        raise NotImplementedError(msg)
+
+    def rollout(self, x: TensorNTCHW) -> TensorNTCHW:
+        """Rollout multiple forward steps: encoding input space into latent space.
+
+        The default implementation simply calls `self.forward` independently on each
         time slice. These are then stacked together to produce the final output.
 
         Args:
@@ -46,22 +59,9 @@ class BaseEncoder(nn.Module):
         """
         return stack(
             [
-                # Apply rollout to each NCHW slice in the NTCHW input
-                self.rollout(x[:, idx_t, :, :, :])
+                # Rollout the model over the input slices, producing an output for each one.
+                self.forward(x[:, idx_t, :, :, :])
                 for idx_t in range(self.n_history_steps)
             ],
             dim=1,
         )
-
-    def rollout(self, x: TensorNCHW) -> TensorNCHW:
-        """Single rollout step: encode NCHW input into NCHW latent space.
-
-        Args:
-            x: TensorNCHW with (batch_size, input_channels, input_height, input_width)
-
-        Returns:
-            TensorNCHW with (batch_size, latent_channels, latent_height, latent_width)
-
-        """
-        msg = "If you are using the default forward method, you must implement rollout."
-        raise NotImplementedError(msg)

--- a/ice_station_zebra/models/encoders/base_encoder.py
+++ b/ice_station_zebra/models/encoders/base_encoder.py
@@ -60,7 +60,7 @@ class BaseEncoder(nn.Module):
         return stack(
             [
                 # Rollout the model over the input slices, producing an output for each one.
-                self.forward(x[:, idx_t, :, :, :])
+                self(x[:, idx_t, :, :, :])
                 for idx_t in range(self.n_history_steps)
             ],
             dim=1,

--- a/ice_station_zebra/models/encoders/cnn_encoder.py
+++ b/ice_station_zebra/models/encoders/cnn_encoder.py
@@ -60,8 +60,8 @@ class CNNEncoder(BaseEncoder):
         # Combine the layers sequentially
         self.model = nn.Sequential(*layers)
 
-    def rollout(self, x: TensorNCHW) -> TensorNCHW:
-        """Single rollout step: encode NCHW input into NCHW latent space.
+    def forward(self, x: TensorNCHW) -> TensorNCHW:
+        """Forward process. Encode input space into latent space for a single timestep.
 
         Args:
             x: TensorNCHW with (batch_size, input_channels, input_height, input_width)

--- a/ice_station_zebra/models/encoders/cnn_encoder.py
+++ b/ice_station_zebra/models/encoders/cnn_encoder.py
@@ -61,7 +61,7 @@ class CNNEncoder(BaseEncoder):
         self.model = nn.Sequential(*layers)
 
     def forward(self, x: TensorNCHW) -> TensorNCHW:
-        """Forward process. Encode input space into latent space for a single timestep.
+        """Forward step: encode input space into latent space with a CNN.
 
         Args:
             x: TensorNCHW with (batch_size, input_channels, input_height, input_width)

--- a/ice_station_zebra/models/encoders/naive_linear_encoder.py
+++ b/ice_station_zebra/models/encoders/naive_linear_encoder.py
@@ -35,7 +35,7 @@ class NaiveLinearEncoder(BaseEncoder):
         self.model = nn.Sequential(*layers)
 
     def forward(self, x: TensorNCHW) -> TensorNCHW:
-        """Forward process. Encode input space into latent space for a single timestep.
+        """Forward step: encode input space into latent space with a linear transform.
 
         Args:
             x: TensorNCHW with (batch_size, input_channels, input_height, input_width)

--- a/ice_station_zebra/models/encoders/naive_linear_encoder.py
+++ b/ice_station_zebra/models/encoders/naive_linear_encoder.py
@@ -34,8 +34,8 @@ class NaiveLinearEncoder(BaseEncoder):
         # Combine the layers sequentially
         self.model = nn.Sequential(*layers)
 
-    def rollout(self, x: TensorNCHW) -> TensorNCHW:
-        """Single rollout step: encode NCHW input into NCHW latent space.
+    def forward(self, x: TensorNCHW) -> TensorNCHW:
+        """Forward process. Encode input space into latent space for a single timestep.
 
         Args:
             x: TensorNCHW with (batch_size, input_channels, input_height, input_width)

--- a/ice_station_zebra/models/processors/base_processor.py
+++ b/ice_station_zebra/models/processors/base_processor.py
@@ -39,21 +39,23 @@ class BaseProcessor(nn.Module):
         msg = "If you are using the default forward method, you must implement rollout."
         raise NotImplementedError(msg)
 
-    def rollout(self, x: TensorNTCHW) -> TensorNTCHW:
+    def rollout(self, x: TensorNTCHW, y: TensorNTCHW | None = None) -> TensorNTCHW:  # noqa: ARG002
         """Rollout multiple forward steps: process in latent space.
 
         The default implementation simply calls `self.forward` on each time slice until
         a sufficient number of forecast steps have been produced. These are then stacked
         together to produce the final output.
 
-        If you want to handle the NTCHW tensors directly, simply override this method in
-        your child class.
+        If you want to handle the NTCHW tensors directly, or to use the target tensor for
+        model training simply override this method in your child class.
 
         Args:
-            x: TensorNTCHW with (batch_size, n_history_steps, n_latent_channels_total, latent_height, latent_width)
+            x: Input TensorNTCHW with (batch_size, n_history_steps, n_latent_channels_total, latent_height, latent_width)
+            y: during training: Target TensorNTCHW with (batch_size, n_forecast_steps, n_latent_channels_total, latent_height, latent_width)
+               otherwise:       None
 
         Returns:
-            TensorNTCHW with (batch_size, n_forecast_steps, n_latent_channels_total, latent_height, latent_width)
+            Predicted TensorNTCHW with (batch_size, n_forecast_steps, n_latent_channels_total, latent_height, latent_width)
 
         """
         # Cut the NTCHW input into NCHW slices

--- a/ice_station_zebra/models/processors/base_processor.py
+++ b/ice_station_zebra/models/processors/base_processor.py
@@ -66,7 +66,7 @@ class BaseProcessor(nn.Module):
         # predict when n_forecast_steps > n_history_steps.
         outputs: list[TensorNCHW] = []
         for _ in range(self.n_forecast_steps):
-            outputs.append(self.forward(nchw_slices.pop(0)))
+            outputs.append(self(nchw_slices.pop(0)))
             nchw_slices.append(outputs[-1])
 
         # Stack the outputs up as a new time dimension

--- a/ice_station_zebra/models/processors/base_processor.py
+++ b/ice_station_zebra/models/processors/base_processor.py
@@ -27,7 +27,7 @@ class BaseProcessor(nn.Module):
         self.n_history_steps = n_history_steps
 
     def forward(self, x: TensorNCHW) -> TensorNCHW:
-        """Forward process in NCHW latent space for a single timestep.
+        """Forward step: process in NCHW latent space for a single timestep.
 
         Args:
             x: TensorNCHW with (batch_size, n_latent_channels_total, latent_height, latent_width)
@@ -40,7 +40,7 @@ class BaseProcessor(nn.Module):
         raise NotImplementedError(msg)
 
     def rollout(self, x: TensorNTCHW, y: TensorNTCHW | None = None) -> TensorNTCHW:  # noqa: ARG002
-        """Rollout multiple forward steps: process in latent space.
+        """Process in latent space across multiple timesteps.
 
         The default implementation simply calls `self.forward` on each time slice until
         a sufficient number of forecast steps have been produced. These are then stacked

--- a/ice_station_zebra/models/processors/base_processor.py
+++ b/ice_station_zebra/models/processors/base_processor.py
@@ -19,18 +19,30 @@ class BaseProcessor(nn.Module):
         data_space: DataSpace,
         n_forecast_steps: int,
         n_history_steps: int,
-        # n_latent_channels_total: int,
     ) -> None:
-        """Initialise a NullProcessor."""
+        """Initialise a BaseProcessor."""
         super().__init__()
         self.data_space = data_space
         self.n_forecast_steps = n_forecast_steps
         self.n_history_steps = n_history_steps
 
-    def forward(self, x: TensorNTCHW) -> TensorNTCHW:
-        """Forward step: process in latent space.
+    def forward(self, x: TensorNCHW) -> TensorNCHW:
+        """Forward process in NCHW latent space for a single timestep.
 
-        The default implementation simply calls `self.rollout` on each time slice until
+        Args:
+            x: TensorNCHW with (batch_size, n_latent_channels_total, latent_height, latent_width)
+
+        Returns:
+            TensorNCHW with (batch_size, n_latent_channels_total, latent_height, latent_width)
+
+        """
+        msg = "If you are using the default forward method, you must implement rollout."
+        raise NotImplementedError(msg)
+
+    def rollout(self, x: TensorNTCHW) -> TensorNTCHW:
+        """Rollout multiple forward steps: process in latent space.
+
+        The default implementation simply calls `self.forward` on each time slice until
         a sufficient number of forecast steps have been produced. These are then stacked
         together to produce the final output.
 
@@ -47,26 +59,13 @@ class BaseProcessor(nn.Module):
         # Cut the NTCHW input into NCHW slices
         nchw_slices = [x[:, idx_t, :, :, :] for idx_t in range(self.n_history_steps)]
 
-        # Run the model over the input slices, producing an output for each one.
+        # Rollout the model over the input slices, producing an output for each one.
         # Also append the predictions to the list of input slices, so that we can still
         # predict when n_forecast_steps > n_history_steps.
         outputs: list[TensorNCHW] = []
         for _ in range(self.n_forecast_steps):
-            outputs.append(self.rollout(nchw_slices.pop(0)))
+            outputs.append(self.forward(nchw_slices.pop(0)))
             nchw_slices.append(outputs[-1])
 
         # Stack the outputs up as a new time dimension
         return stack(outputs, dim=1)
-
-    def rollout(self, x: TensorNCHW) -> TensorNCHW:
-        """Single rollout step: process in NCHW latent space.
-
-        Args:
-            x: TensorNCHW with (batch_size, n_latent_channels_total, latent_height, latent_width)
-
-        Returns:
-            TensorNCHW with (batch_size, n_latent_channels_total, latent_height, latent_width)
-
-        """
-        msg = "If you are using the default forward method, you must implement rollout."
-        raise NotImplementedError(msg)

--- a/ice_station_zebra/models/processors/ddpm.py
+++ b/ice_station_zebra/models/processors/ddpm.py
@@ -34,7 +34,7 @@ class DDPMProcessor(BaseProcessor):
         self.diffusion = GaussianDiffusion(timesteps=timesteps)
 
     def forward(self, x: TensorNCHW) -> TensorNCHW:
-        """Generate NCHW output with diffusion for a single timestep.
+        """Forward step: generate NCHW output with diffusion for a single timestep.
 
         Args:
             x: TensorNCHW with (batch_size, n_latent_channels_total, latent_height, latent_width)

--- a/ice_station_zebra/models/processors/ddpm.py
+++ b/ice_station_zebra/models/processors/ddpm.py
@@ -33,8 +33,8 @@ class DDPMProcessor(BaseProcessor):
         self.ema = ExponentialMovingAverage(self.model.parameters(), decay=0.995)
         self.diffusion = GaussianDiffusion(timesteps=timesteps)
 
-    def rollout(self, x: TensorNCHW) -> TensorNCHW:
-        """Generate a single NCHW output with diffusion.
+    def forward(self, x: TensorNCHW) -> TensorNCHW:
+        """Generate NCHW output with diffusion for a single timestep.
 
         Args:
             x: TensorNCHW with (batch_size, n_latent_channels_total, latent_height, latent_width)

--- a/ice_station_zebra/models/processors/null.py
+++ b/ice_station_zebra/models/processors/null.py
@@ -27,7 +27,7 @@ class NullProcessor(BaseProcessor):
         super().__init__(**kwargs)
         self.model = nn.Identity()
 
-    def rollout(self, x: TensorNCHW) -> TensorNCHW:
+    def forward(self, x: TensorNCHW) -> TensorNCHW:
         """Apply identity to NCHW tensor.
 
         Args:

--- a/ice_station_zebra/models/processors/null.py
+++ b/ice_station_zebra/models/processors/null.py
@@ -28,7 +28,7 @@ class NullProcessor(BaseProcessor):
         self.model = nn.Identity()
 
     def forward(self, x: TensorNCHW) -> TensorNCHW:
-        """Apply identity to NCHW tensor.
+        """Forward step: apply identity to NCHW tensor.
 
         Args:
             x: TensorNCHW with (batch_size, n_latent_channels_total, latent_height, latent_width)

--- a/ice_station_zebra/models/processors/unet.py
+++ b/ice_station_zebra/models/processors/unet.py
@@ -83,7 +83,7 @@ class UNetProcessor(BaseProcessor):
         )
 
     def forward(self, x: TensorNCHW) -> TensorNCHW:
-        """Apply UNet model to NCHW tensor for a single timestep.
+        """Forward step: apply UNet model to NCHW tensor for a single timestep.
 
         Args:
             x: TensorNCHW with (batch_size, n_latent_channels_total, latent_height, latent_width)

--- a/ice_station_zebra/models/processors/unet.py
+++ b/ice_station_zebra/models/processors/unet.py
@@ -82,8 +82,8 @@ class UNetProcessor(BaseProcessor):
             channels[0], self.data_space.channels, kernel_size=1, padding="same"
         )
 
-    def rollout(self, x: TensorNCHW) -> TensorNCHW:
-        """Apply UNet model to NCHW tensor.
+    def forward(self, x: TensorNCHW) -> TensorNCHW:
+        """Apply UNet model to NCHW tensor for a single timestep.
 
         Args:
             x: TensorNCHW with (batch_size, n_latent_channels_total, latent_height, latent_width)

--- a/ice_station_zebra/models/zebra_model.py
+++ b/ice_station_zebra/models/zebra_model.py
@@ -72,8 +72,15 @@ class ZebraModel(LightningModule, ABC):
     def forward(self, inputs: dict[str, TensorNTCHW]) -> TensorNTCHW:
         """Forward step of the model.
 
-        - start with multiple [NTCHW] inputs each with shape [batch, n_history_steps, C_input_k, H_input_k, W_input_k]
-        - return a single [NTCHW] output [batch, n_forecast_steps, C_output, H_output, W_output]
+        - start with multiple [NTCHW] inputs, one for each input dataset
+        - return a single [NTCHW] output representing the predicted output
+
+        Args:
+            inputs: Dictionary of dataset name to TensorNTCHW with shape [batch, n_history_steps, C_input_k, H_input_k, W_input_k]
+
+        Returns:
+            Predicted TensorNTCHW with shape [batch, n_forecast_steps, C_output, H_output, W_output]
+
         """
 
     def loss(self, prediction: TensorNTCHW, target: TensorNTCHW) -> torch.Tensor:

--- a/ice_station_zebra/models/zebra_model.py
+++ b/ice_station_zebra/models/zebra_model.py
@@ -113,7 +113,7 @@ class ZebraModel(LightningModule, ABC):
         """Run the training step.
 
         - Separate the batch into inputs and target
-        - Run inputs through the model
+        - Run inputs and target through the model
         - Calculate the loss wrt. the target
 
         Args:
@@ -125,7 +125,7 @@ class ZebraModel(LightningModule, ABC):
             A Tensor containing the loss for the batch.
 
         """
-        target = batch.pop("target")
+        target = batch["target"].clone().detach()
         prediction = self(batch)
         return self.loss(prediction, target)
 

--- a/ice_station_zebra/models/zebra_model.py
+++ b/ice_station_zebra/models/zebra_model.py
@@ -159,7 +159,7 @@ class ZebraModel(LightningModule, ABC):
             A Tensor containing the loss for the batch.
 
         """
-        target = batch.pop("target")
+        target = batch["target"].clone().detach()
         prediction = self(batch)
         loss = self.loss(prediction, target)
         self.log("validation_loss", loss)

--- a/tests/models/test_decoders.py
+++ b/tests/models/test_decoders.py
@@ -42,7 +42,7 @@ class TestDecoders:
                 n_forecast_steps=test_n_forecast_steps,
             ),
         }[test_decoder_cls]
-        result: torch.Tensor = decoder(
+        result: torch.Tensor = decoder.rollout(
             torch.randn(
                 test_batch_size,
                 test_n_forecast_steps,

--- a/tests/models/test_encoders.py
+++ b/tests/models/test_encoders.py
@@ -38,7 +38,7 @@ class TestEncoders:
                 n_history_steps=test_n_history_steps,
             ),
         }[test_encoder_cls]
-        result: torch.Tensor = encoder(
+        result: torch.Tensor = encoder.rollout(
             torch.randn(
                 test_batch_size,
                 test_n_history_steps,

--- a/tests/models/test_processors.py
+++ b/tests/models/test_processors.py
@@ -33,7 +33,7 @@ class TestBaseProcessor:
             NotImplementedError,
             match="If you are using the default forward method, you must implement rollout.",
         ):
-            processor(
+            processor.rollout(
                 torch.randn(
                     test_batch_size,
                     test_n_history_steps,
@@ -62,7 +62,7 @@ class TestNullProcessor:
             n_forecast_steps=test_n_forecast_steps,
             n_history_steps=test_n_history_steps,
         )
-        result: torch.Tensor = processor(
+        result: torch.Tensor = processor.rollout(
             torch.randn(
                 test_batch_size,
                 test_n_history_steps,
@@ -145,9 +145,9 @@ class TestUNetProcessor:
         if height % 16 or width % 16:
             msg = f"Latent space height and width must be divisible by 16 with a factor more than 1, got {height} and {width}."
             with pytest.raises(ValueError, match=msg):
-                processor(x)
+                processor.rollout(x)
         else:
-            result: torch.Tensor = processor(x)
+            result: torch.Tensor = processor.rollout(x)
             assert result.shape == (
                 test_batch_size,
                 test_n_forecast_steps,


### PR DESCRIPTION
Make the `target` tensor available to instances of `BaseProcessor` during the encode-process-decode workflow.

Child classes will need to override `rollout` which has the following type signature `rollout(self, x: TensorNTCHW, y: TensorNTCHW | None = None) -> TensorNTCHW`. The inputs are:

- `x` input tensor in latent space `(batch_size, n_history_steps, n_latent_channels_total, latent_height, latent_width)`
- `y`: target tensor in latent space `(batch_size, n_forecast_steps, n_latent_channels_total, latent_height, latent_width)`
- output: predicted tensor in latent space `(batch_size, n_forecast_steps, n_latent_channels_total, latent_height, latent_width)`

:warning: The same `rollout` method is used for test/train/validate/predict. For `train` and `validate`, `y` will be provided, but for `test` and `predict` it will be `None`. Code that wants to use this tensor should check for `y is None` before doing so.

## Other changes
Swapped the definition of `forward` and `rollout`. `forward` now does `TensorNCHW -> TensorNCHW` for a single timestep and the default implementation of `rollout` is to call `forward` N times. This should better correspond to the logical meanings of `forward` and `rollout`.

Closes #108 
