### PR TITLE
Compatibility fixes for ViT

### DIFF
--- a/ice_station_zebra/config/model/cnn_vit_cnn.yaml
+++ b/ice_station_zebra/config/model/cnn_vit_cnn.yaml
@@ -10,14 +10,12 @@ encoder:
 
 processor:
   _target_: ice_station_zebra.models.processors.VitProcessor
-  img_size: 192
   patch_size: 16
   emb_dim: 128
   depth: 3
   heads: 4
   mlp_dim: 256
   dropout: 0.3
-  start_out_channels: 28 # Initial number of channels
 
 decoder:
   _target_: ice_station_zebra.models.decoders.CNNDecoder

--- a/ice_station_zebra/config/model/naive_vit_naive.yaml
+++ b/ice_station_zebra/config/model/naive_vit_naive.yaml
@@ -8,14 +8,12 @@ encoder:
 
 processor:
   _target_: ice_station_zebra.models.processors.VitProcessor
-  img_size: 192
   patch_size: 16
   emb_dim: 128
   depth: 3
   heads: 4
   mlp_dim: 256
   dropout: 0.3
-  start_out_channels: 28 # Initial number of channels
 
 decoder:
   _target_: ice_station_zebra.models.decoders.NaiveLinearDecoder

--- a/ice_station_zebra/models/processors/vit.py
+++ b/ice_station_zebra/models/processors/vit.py
@@ -20,26 +20,29 @@ from ice_station_zebra.types import TensorNCHW
 from .base_processor import BaseProcessor
 
 
-# class VitProcessor(nn.Module):
 class VitProcessor(BaseProcessor):
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
-        start_out_channels: int,
-        img_size: int,
-        patch_size: int,
-        emb_dim: int,
+        *,
         depth: int,
+        dropout: float,
+        emb_dim: int,
         heads: int,
         mlp_dim: int,
-        dropout: float,
+        patch_size: int,
         **kwargs: Any,
     ) -> None:
         """Initialize Vision Transformer model for sea ice forecasting."""
         super().__init__(**kwargs)
 
-        self.img_size = img_size
+        # Ensure input is square
+        if self.data_space.shape[0] != self.data_space.shape[1]:
+            msg = "The height and width of the input are not equal."
+            raise ValueError(msg)
+
+        self.img_size = self.data_space.shape[0]
         self.patch_size = patch_size
-        self.out_channels = start_out_channels
+        self.out_channels = self.data_space.channels
 
         self.patch_embed = PatchEmbedding(
             self.data_space.channels, patch_size, emb_dim, self.img_size


### PR DESCRIPTION
- rename config file to match existing pattern
- add new cnn-vit-cnn config
- check for invalid image size
- take image size and output channels from `self.data_space`