### PR TITLE
Initial fix for patch related checkerboard effect in ViT

### DIFF
--- a/ice_station_zebra/models/processors/vit.py
+++ b/ice_station_zebra/models/processors/vit.py
@@ -66,6 +66,10 @@ class VitProcessor(BaseProcessor):
             nn.Linear(emb_dim, patch_size * patch_size * self.out_channels),
         )
 
+        self.smooth = nn.Conv2d(
+            self.out_channels, self.out_channels, kernel_size=3, padding=1
+        )
+
     def forward(self, x: TensorNCHW) -> TensorNCHW:
         """Forward pass through the ViT model for a single timestep.
 
@@ -99,4 +103,6 @@ class VitProcessor(BaseProcessor):
         x = x.permute(0, 3, 1, 4, 2, 5)
 
         # Shape is batch, out_channels, height, width
-        return x.reshape(batch, self.out_channels, self.img_size, self.img_size)
+        x = x.reshape(batch, self.out_channels, self.img_size, self.img_size)
+
+        return self.smooth(x)


### PR DESCRIPTION
Independent predictions for each patch were originally stitched together without considering boundaries between patches, causing a checkerboard effect. An initial attempt using a smaller patch size and adding a convolutional smoothing layer largely removed this effect.