### PR TITLE
Delete ice_station_zebra/config/demo.yaml

### DIFF
--- a/ice_station_zebra/config/demo.yaml
+++ b/ice_station_zebra/config/demo.yaml
@@ -1,6 +1,0 @@
-defaults:
-  - base
-  - override /datasets: osisaf-sic-south-2019-12-24h-v1
-  - override /model: naive_null_naive
-
-base_path: mydata/


### PR DESCRIPTION
This was an early version of the yaml needed to run the demo notebook. It was replaced by demo_nb.yaml, so it should be deleted