### PR TITLE
URGENT: exclude compromised lightning versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "icenet==0.2.7", # newer versions require netCDF4<1.6.1 which does not work on macOS 15
     "imageio-ffmpeg>=0.6.0",
     "jaxtyping>=0.3.2",
-    "lightning>=2.5.1",
+    "lightning>=2.5.1,!=2.6.2,!=2.6.3", # 2.6.2 and 2.6.3 are compromised https://www.aikido.dev/blog/pytorch-lightning-pypi-compromise-mini-shai-hulud
     "matplotlib>=3.10.3",
     "netcdf4>=1.7.0",
     "pillow>=11.3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1845,7 +1845,7 @@ requires-dist = [
     { name = "icenet", specifier = "==0.2.7" },
     { name = "imageio-ffmpeg", specifier = ">=0.6.0" },
     { name = "jaxtyping", specifier = ">=0.3.2" },
-    { name = "lightning", specifier = ">=2.5.1" },
+    { name = "lightning", specifier = ">=2.5.1,!=2.6.2,!=2.6.3" },
     { name = "matplotlib", specifier = ">=3.10.3" },
     { name = "netcdf4", specifier = ">=1.7.0" },
     { name = "pillow", specifier = ">=11.3.0" },


### PR DESCRIPTION
Lightning 2.6.2 and 2.6.3 are compromised https://www.aikido.dev/blog/pytorch-lightning-pypi-compromise-mini-shai-hulud

Check whether you have installed them and treat all SSH keys, git/Azure/AWS etc. credentials as compromised.