### PR TITLE
Merge touching date ranges in SingleDataset (#279)

### DIFF
--- a/icenet_mp/data_loaders/single_dataset.py
+++ b/icenet_mp/data_loaders/single_dataset.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Sequence
 from functools import cached_property
 from pathlib import Path
@@ -12,6 +13,31 @@ from icenet_mp.types import ArrayCHW, ArrayTCHW, DataSpace, Hemisphere
 from icenet_mp.utils import normalise_date
 
 ArrayType = TypeVar("ArrayType", ArrayCHW, ArrayTCHW)
+
+logger = logging.getLogger(__name__)
+
+# helpers: check if any two stacks touch (stack B start is consecutive to stack A end)  --> merge if yes  
+def _ranges_touch(
+    prev: dict[str, str | None],
+    nxt: dict[str, str | None],
+    frequency: np.timedelta64,
+) -> bool:
+    """Whether two ranges touch at the end points.
+
+    Yes when the next range start_date is consecutive to the
+    previous range end_date, ie, no missing day between them (overlap counts
+    too). Open-ended (None) bounds are out of scope, dont merge -- diverse to future fixes/discussions.
+    """
+    if prev["end"] is None or nxt["start"] is None:
+        return False
+    return np.datetime64(nxt["start"]) <= np.datetime64(prev["end"]) + frequency
+
+
+def _later_end(a: dict[str, str | None], b: dict[str, str | None]) -> str | None:
+    """Return the end of the merged span."""
+    if a["end"] is None or b["end"] is None:
+        return None
+    return a["end"] if np.datetime64(a["end"]) >= np.datetime64(b["end"]) else b["end"]
 
 
 class SingleDataset(Dataset):
@@ -73,6 +99,41 @@ class SingleDataset(Dataset):
         return idx2anemoi
 
     @cached_property
+    def _merged_date_ranges(self) -> list[dict[str, str | None]]:
+        """Fuse touching/overlapping ranges into single spans.
+
+        Adjacent ranges touching/overlapping must merge into one
+        single Anemoi subset, or else a run that straddles the range gap/seam is
+        approved against the time step outside the range but fetching is still restricted 
+        to be within the range only, therefore will comes back short, and fails to reshape (issue #279). 
+        Merges are logged to remind the user that their config ranges are touching.
+        """
+        if len(self._date_ranges)  <=  1:
+            return [dict(date_range) for date_range in self._date_ranges]
+        
+        frequency = np.timedelta64(self.load_dataset(self._input_files).frequency)
+        merged: list[dict[str, str | None]] = []
+        for date_range in self._date_ranges:
+            if merged and _ranges_touch(merged[-1], date_range, frequency):
+                prev = merged.pop()
+                fused: dict[str, str | None] = {
+                    "start": prev["start"],
+                    "end": _later_end(prev, date_range),
+                }
+                logger.warning(
+                    "Merged touching date ranges %s and %s into %s for dataset %r "
+                    "Please check cofig file range setting if unintended",
+                    prev,
+                    date_range,
+                    fused,
+                    self._name,
+                )
+                merged.append(fused)
+            else:
+                merged.append(dict(date_range))
+        return merged
+
+    @cached_property
     def dataslices(self) -> list[AnemoiDataset]:
         """Get all slices of contiguous dates from the underlying Anemoi dataset."""
         return [
@@ -82,7 +143,7 @@ class SingleDataset(Dataset):
                 end=date_range["end"],
                 **({"select": self._variables} if self._variables else {}),
             )
-            for date_range in self._date_ranges
+            for date_range in self._merged_date_ranges
         ]
 
     @cached_property

--- a/icenet_mp/data_loaders/single_dataset.py
+++ b/icenet_mp/data_loaders/single_dataset.py
@@ -79,15 +79,14 @@ class SingleDataset(Dataset):
     ) -> list[dict[str, str | None]]:
         """Sort the ranges, then merge overlapping or touching ones into single spans.
 
-        Ranges that overlap or touch must merge into one Anemoi subset, or a run
-        that crosses the seam is approved against a date outside the range while
-        the fetch stays inside it, so the read comes back short and fails to
-        reshape. Two ranges merge when the later one starts on or before the day
-        after the earlier one ends; the merged span runs from the earliest start
-        to the latest end. A "None" bound is open: a "None" start is before any
-        date and a "None" end is after any date, so an open bound always overlaps
-        its neighbour. Each merge is logged so a user notices that their config
-        ranges were altered (e.g. a mistyped year that creates an overlap).
+        Ranges that overlap/touch must merge into one Anemoi subset, or data fetching step comes back
+        short and fails to reshape. Two ranges merge when the later one starts on/before the day
+        after the earlier one finishes; the merged span is the union of all ranges.
+
+        A "None" bound is open, an open-ended previous range always overlap with the later ranges, an
+        open-started later range always overlap with previous ranges.
+
+        Each merge is logged so a user notices that their config ranges were altered and verifies.
         """
         ranges = sorted(
             date_ranges, key=lambda dr: "" if dr["start"] is None else dr["start"]
@@ -103,11 +102,10 @@ class SingleDataset(Dataset):
         ) -> bool:
             """Whether nxt overlaps or is consecutive with prev, so they should merge.
 
-            Ranges are sorted by start, so nxt never begins before prev. They
-            merge when nxt starts on or before the day after prev ends. An open
-            end on prev (None = after any date) covers everything later, and an
-            open start on nxt (None = before any date) sits inside prev, so in
-            either case they always merge.
+            Ranges are sorted by start. They merge when nxt starts on or before the
+            day after prev ends. An open end on prev (None = after any date) covers
+            everything later, and an open start on nxt (None = before any date) sits
+            inside prev, so in either case they always merge.
             """
             if prev["end"] is None or nxt["start"] is None:
                 return True

--- a/icenet_mp/data_loaders/single_dataset.py
+++ b/icenet_mp/data_loaders/single_dataset.py
@@ -77,15 +77,17 @@ class SingleDataset(Dataset):
     def normalise_date_ranges(
         date_ranges: Sequence[dict[str, str | None]],
     ) -> list[dict[str, str | None]]:
-        """Sort the ranges, then merge touching ones into single spans.
+        """Sort the ranges, then merge overlapping or touching ones into single spans.
 
-        Adjacent ranges that touch must merge into one Anemoi subset, or a run
+        Ranges that overlap or touch must merge into one Anemoi subset, or a run
         that crosses the seam is approved against a date outside the range while
         the fetch stays inside it, so the read comes back short and fails to
-        reshape. Merges are logged so a user notices adjoining config ranges.
-        The merged span just takes the later range's end. Note that:
-        a "None" in prev and nxt means the first/last available date in the data;
-        overlapping ranges are left as-is (not merged), as are open-ended bounds.
+        reshape. Two ranges merge when the later one starts on or before the day
+        after the earlier one ends; the merged span runs from the earliest start
+        to the latest end. A "None" bound is open: a "None" start is before any
+        date and a "None" end is after any date, so an open bound always overlaps
+        its neighbour. Each merge is logged so a user notices that their config
+        ranges were altered (e.g. a mistyped year that creates an overlap).
         """
         ranges = sorted(
             date_ranges, key=lambda dr: "" if dr["start"] is None else dr["start"]
@@ -93,34 +95,42 @@ class SingleDataset(Dataset):
         if len(ranges) <= 1:
             return [dict(date_range) for date_range in ranges]
 
-        #  Assume data always has a daily freuquency; for future updates: read from source metadata
+        #  Assume data always has a daily frequency; for future updates: read from source metadata
         frequency = np.timedelta64(1, "D")
 
-        def _ranges_touch(
+        def _ranges_overlap_or_touch(
             prev: dict[str, str | None], nxt: dict[str, str | None]
         ) -> bool:
-            """Whether nxt is adjacent to prev: starts on, or the day after, prev's end.
+            """Whether nxt overlaps or is consecutive with prev, so they should merge.
 
-            Only consecutive ranges merge. Overlapping ranges (nxt starts before
-            prev ends) and open-ended (None) bounds fall through to False and are
-            left untouched.
+            Ranges are sorted by start, so nxt never begins before prev. They
+            merge when nxt starts on or before the day after prev ends. An open
+            end on prev (None = after any date) covers everything later, and an
+            open start on nxt (None = before any date) sits inside prev, so in
+            either case they always merge.
             """
             if prev["end"] is None or nxt["start"] is None:
-                return False
-            end = np.datetime64(prev["end"])
-            start = np.datetime64(nxt["start"])
-            return bool(end <= start) and bool(start <= end + frequency)
+                return True
+            return bool(
+                np.datetime64(nxt["start"]) <= np.datetime64(prev["end"]) + frequency
+            )
+
+        def _later_end(a: str | None, b: str | None) -> str | None:
+            """Return the later of two end dates; None (open) is after any date."""
+            if a is None or b is None:
+                return None
+            return a if np.datetime64(a) >= np.datetime64(b) else b
 
         merged: list[dict[str, str | None]] = []
         for date_range in ranges:
-            if merged and _ranges_touch(merged[-1], date_range):
+            if merged and _ranges_overlap_or_touch(merged[-1], date_range):
                 prev = merged.pop()
                 fused: dict[str, str | None] = {
                     "start": prev["start"],
-                    "end": date_range["end"],
+                    "end": _later_end(prev["end"], date_range["end"]),
                 }
                 logger.warning(
-                    "Merged touching date ranges %s and %s into %s. "
+                    "Merged overlapping or touching date ranges %s and %s into %s. "
                     "Please check config file range setting if unintended",
                     prev,
                     date_range,

--- a/icenet_mp/data_loaders/single_dataset.py
+++ b/icenet_mp/data_loaders/single_dataset.py
@@ -85,7 +85,7 @@ class SingleDataset(Dataset):
         reshape. Merges are logged so a user notices adjoining config ranges.
         The merged span just takes the later range's end. Note that:
         a "None" in prev and nxt means the first/last available date in the data;
-        overlapping ranges are assumed unused, no need to fix;
+        overlapping ranges are left as-is (not merged), as are open-ended bounds.
         """
         ranges = sorted(
             date_ranges, key=lambda dr: "" if dr["start"] is None else dr["start"]
@@ -99,12 +99,17 @@ class SingleDataset(Dataset):
         def _ranges_touch(
             prev: dict[str, str | None], nxt: dict[str, str | None]
         ) -> bool:
-            """Check whether nxt starts within one time-step of prev's end."""
+            """Whether nxt is adjacent to prev: starts on, or the day after, prev's end.
+
+            Only consecutive ranges merge. Overlapping ranges (nxt starts before
+            prev ends) and open-ended (None) bounds fall through to False and are
+            left untouched.
+            """
             if prev["end"] is None or nxt["start"] is None:
                 return False
-            return bool(
-                np.datetime64(nxt["start"]) <= np.datetime64(prev["end"]) + frequency
-            )
+            end = np.datetime64(prev["end"])
+            start = np.datetime64(nxt["start"])
+            return bool(end <= start) and bool(start <= end + frequency)
 
         merged: list[dict[str, str | None]] = []
         for date_range in ranges:

--- a/icenet_mp/data_loaders/single_dataset.py
+++ b/icenet_mp/data_loaders/single_dataset.py
@@ -17,30 +17,6 @@ ArrayType = TypeVar("ArrayType", ArrayCHW, ArrayTCHW)
 logger = logging.getLogger(__name__)
 
 
-# helpers: check if any two stacks touch (stack B start is consecutive to stack A end)  --> merge if yes
-def _ranges_touch(
-    prev: dict[str, str | None],
-    nxt: dict[str, str | None],
-    frequency: np.timedelta64,
-) -> bool:
-    """Whether two ranges touch at the end points.
-
-    Yes when the next range start_date is consecutive to the
-    previous range end_date, ie, no missing day between them (overlap counts
-    too). Open-ended (None) bounds are out of scope, dont merge -- diverse to future fixes/discussions.
-    """
-    if prev["end"] is None or nxt["start"] is None:
-        return False
-    return bool(np.datetime64(nxt["start"]) <= np.datetime64(prev["end"]) + frequency)
-
-
-def _later_end(a: dict[str, str | None], b: dict[str, str | None]) -> str | None:
-    """Return the end of the merged span."""
-    if a["end"] is None or b["end"] is None:
-        return None
-    return a["end"] if np.datetime64(a["end"]) >= np.datetime64(b["end"]) else b["end"]
-
-
 class SingleDataset(Dataset):
     """A dataset containing one or more timeslices of data from a single source."""
 
@@ -62,9 +38,7 @@ class SingleDataset(Dataset):
         We reshape this to CHW before returning.
         """
         super().__init__()
-        self._date_ranges = sorted(
-            date_ranges, key=lambda dr: "" if dr["start"] is None else dr["start"]
-        )
+        self._date_ranges = self.normalise_date_ranges(date_ranges)
         self.hemisphere: Hemisphere = (
             "north"
             if any("north" in str(input_file).lower() for input_file in input_files)
@@ -99,35 +73,53 @@ class SingleDataset(Dataset):
                     idx2anemoi[idx_global] = (idx_ds, idx_date)
         return idx2anemoi
 
-    @cached_property
-    def _merged_date_ranges(self) -> list[dict[str, str | None]]:
-        """Fuse touching/overlapping ranges into single spans.
+    @staticmethod
+    def normalise_date_ranges(
+        date_ranges: Sequence[dict[str, str | None]],
+    ) -> list[dict[str, str | None]]:
+        """Sort the ranges, then merge touching ones into single spans.
 
-        Adjacent ranges touching/overlapping must merge into one
-        single Anemoi subset, or else a run that straddles the range gap/seam is
-        approved against the time step outside the range but fetching is still restricted
-        to be within the range only, therefore will comes back short, and fails to reshape (issue #279).
-        Merges are logged to remind the user that their config ranges are touching.
+        Adjacent ranges that touch must merge into one Anemoi subset, or a run
+        that crosses the seam is approved against a date outside the range while
+        the fetch stays inside it, so the read comes back short and fails to
+        reshape. Merges are logged so a user notices adjoining config ranges.
+        The merged span just takes the later range's end. Note that:
+        a "None" in prev and nxt means the first/last available date in the data;
+        overlapping ranges are assumed unused, no need to fix;
         """
-        if len(self._date_ranges) <= 1:
-            return [dict(date_range) for date_range in self._date_ranges]
+        ranges = sorted(
+            date_ranges, key=lambda dr: "" if dr["start"] is None else dr["start"]
+        )
+        if len(ranges) <= 1:
+            return [dict(date_range) for date_range in ranges]
 
-        frequency = np.timedelta64(self.load_dataset(self._input_files).frequency)
+        #  Assume data always has a daily freuquency; for future updates: read from source metadata
+        frequency = np.timedelta64(1, "D")
+
+        def _ranges_touch(
+            prev: dict[str, str | None], nxt: dict[str, str | None]
+        ) -> bool:
+            """Check whether nxt starts within one time-step of prev's end."""
+            if prev["end"] is None or nxt["start"] is None:
+                return False
+            return bool(
+                np.datetime64(nxt["start"]) <= np.datetime64(prev["end"]) + frequency
+            )
+
         merged: list[dict[str, str | None]] = []
-        for date_range in self._date_ranges:
-            if merged and _ranges_touch(merged[-1], date_range, frequency):
+        for date_range in ranges:
+            if merged and _ranges_touch(merged[-1], date_range):
                 prev = merged.pop()
                 fused: dict[str, str | None] = {
                     "start": prev["start"],
-                    "end": _later_end(prev, date_range),
+                    "end": date_range["end"],
                 }
                 logger.warning(
-                    "Merged touching date ranges %s and %s into %s for dataset %r "
-                    "Please check cofig file range setting if unintended",
+                    "Merged touching date ranges %s and %s into %s. "
+                    "Please check config file range setting if unintended",
                     prev,
                     date_range,
                     fused,
-                    self._name,
                 )
                 merged.append(fused)
             else:
@@ -144,7 +136,7 @@ class SingleDataset(Dataset):
                 end=date_range["end"],
                 **({"select": self._variables} if self._variables else {}),
             )
-            for date_range in self._merged_date_ranges
+            for date_range in self._date_ranges
         ]
 
     @cached_property

--- a/icenet_mp/data_loaders/single_dataset.py
+++ b/icenet_mp/data_loaders/single_dataset.py
@@ -16,7 +16,8 @@ ArrayType = TypeVar("ArrayType", ArrayCHW, ArrayTCHW)
 
 logger = logging.getLogger(__name__)
 
-# helpers: check if any two stacks touch (stack B start is consecutive to stack A end)  --> merge if yes  
+
+# helpers: check if any two stacks touch (stack B start is consecutive to stack A end)  --> merge if yes
 def _ranges_touch(
     prev: dict[str, str | None],
     nxt: dict[str, str | None],
@@ -30,7 +31,7 @@ def _ranges_touch(
     """
     if prev["end"] is None or nxt["start"] is None:
         return False
-    return np.datetime64(nxt["start"]) <= np.datetime64(prev["end"]) + frequency
+    return bool(np.datetime64(nxt["start"]) <= np.datetime64(prev["end"]) + frequency)
 
 
 def _later_end(a: dict[str, str | None], b: dict[str, str | None]) -> str | None:
@@ -104,13 +105,13 @@ class SingleDataset(Dataset):
 
         Adjacent ranges touching/overlapping must merge into one
         single Anemoi subset, or else a run that straddles the range gap/seam is
-        approved against the time step outside the range but fetching is still restricted 
-        to be within the range only, therefore will comes back short, and fails to reshape (issue #279). 
+        approved against the time step outside the range but fetching is still restricted
+        to be within the range only, therefore will comes back short, and fails to reshape (issue #279).
         Merges are logged to remind the user that their config ranges are touching.
         """
-        if len(self._date_ranges)  <=  1:
+        if len(self._date_ranges) <= 1:
             return [dict(date_range) for date_range in self._date_ranges]
-        
+
         frequency = np.timedelta64(self.load_dataset(self._input_files).frequency)
         merged: list[dict[str, str | None]] = []
         for date_range in self._date_ranges:

--- a/tests/data_loaders/test_single_dataset.py
+++ b/tests/data_loaders/test_single_dataset.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 from pathlib import Path
 
@@ -512,3 +513,36 @@ class TestSingleDataset:
                 {"start": "2020-07-01", "end": None},
             ]
         ) == [{"start": None, "end": None}]
+
+    def test_normalise_date_ranges_warns_on_merge(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A merge emits exactly one warning so the user notices ranges were altered."""
+        with caplog.at_level(logging.WARNING):
+            result = SingleDataset.normalise_date_ranges(
+                [
+                    {"start": "2020-01-01", "end": "2020-06-30"},
+                    {"start": "2020-07-01", "end": "2020-12-31"},
+                ]
+            )
+        assert result == [{"start": "2020-01-01", "end": "2020-12-31"}]
+        merge_warnings = [
+            record
+            for record in caplog.records
+            if record.levelno == logging.WARNING
+            and "Merged overlapping or touching date ranges" in record.getMessage()
+        ]
+        assert len(merge_warnings) == 1
+
+    def test_normalise_date_ranges_single_and_empty_passthrough(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Empty or single-range input is returned unchanged with no merge warning."""
+        with caplog.at_level(logging.WARNING):
+            assert SingleDataset.normalise_date_ranges([]) == []
+            assert SingleDataset.normalise_date_ranges(
+                [{"start": "2020-01-01", "end": "2020-06-30"}]
+            ) == [{"start": "2020-01-01", "end": "2020-06-30"}]
+        assert not [
+            record for record in caplog.records if record.levelno == logging.WARNING
+        ]

--- a/tests/data_loaders/test_single_dataset.py
+++ b/tests/data_loaders/test_single_dataset.py
@@ -459,29 +459,50 @@ class TestSingleDataset:
         ]
         assert SingleDataset.normalise_date_ranges(ranges) == ranges
 
-    def test_normalise_date_ranges_overlap_left_alone(self) -> None:
-        """Overlapping ranges are not merged (and not truncated)."""
-        ranges: list[dict[str, str | None]] = [
-            {"start": "2020-01-01", "end": "2020-12-31"},
-            {"start": "2020-03-01", "end": "2020-06-30"},
-        ]
-        assert SingleDataset.normalise_date_ranges(ranges) == ranges
+    def test_normalise_date_ranges_overlap_merge(self) -> None:
+        """A range fully containing another merges to the outer span (no truncation)."""
+        assert SingleDataset.normalise_date_ranges(
+            [
+                {"start": "2020-01-01", "end": "2020-12-31"},
+                {"start": "2020-03-01", "end": "2020-06-30"},
+            ]
+        ) == [{"start": "2020-01-01", "end": "2020-12-31"}]
 
-    def test_normalise_date_ranges_end_none_left_alone(self) -> None:
-        """An open end (None = last date) overlaps a later range, so it is left alone."""
-        ranges: list[dict[str, str | None]] = [
-            {"start": "2020-01-01", "end": None},
-            {"start": "2020-06-01", "end": "2020-09-30"},
-        ]
-        assert SingleDataset.normalise_date_ranges(ranges) == ranges
+    def test_normalise_date_ranges_partial_overlap_merge(self) -> None:
+        """Partially overlapping ranges merge to earliest start and latest end."""
+        assert SingleDataset.normalise_date_ranges(
+            [
+                {"start": "2025-01-01", "end": "2025-03-31"},
+                {"start": "2025-02-01", "end": "2025-05-31"},
+            ]
+        ) == [{"start": "2025-01-01", "end": "2025-05-31"}]
 
-    def test_normalise_date_ranges_start_none_left_alone(self) -> None:
-        """Two open starts (None = first date) overlap, so they are left alone."""
-        ranges: list[dict[str, str | None]] = [
-            {"start": None, "end": "2020-03-31"},
-            {"start": None, "end": "2020-06-30"},
-        ]
-        assert SingleDataset.normalise_date_ranges(ranges) == ranges
+    def test_normalise_date_ranges_end_none_merge(self) -> None:
+        """An open end (None = after any date) overlaps a later range, so they merge."""
+        assert SingleDataset.normalise_date_ranges(
+            [
+                {"start": "2020-01-01", "end": None},
+                {"start": "2020-06-01", "end": "2020-09-30"},
+            ]
+        ) == [{"start": "2020-01-01", "end": None}]
+
+    def test_normalise_date_ranges_end_none_inside_other_merge(self) -> None:
+        """An open-ended range starting inside another keeps the earliest start, open end."""
+        assert SingleDataset.normalise_date_ranges(
+            [
+                {"start": "2020-06-01", "end": None},
+                {"start": "2020-01-01", "end": "2020-09-30"},
+            ]
+        ) == [{"start": "2020-01-01", "end": None}]
+
+    def test_normalise_date_ranges_start_none_merge(self) -> None:
+        """Two open starts (None = before any date) overlap, so they merge."""
+        assert SingleDataset.normalise_date_ranges(
+            [
+                {"start": None, "end": "2020-03-31"},
+                {"start": None, "end": "2020-06-30"},
+            ]
+        ) == [{"start": None, "end": "2020-06-30"}]
 
     def test_normalise_date_ranges_open_outer_ends_merge(self) -> None:
         """Open-beginning + open-ending halves that meet merge to the whole range."""

--- a/tests/data_loaders/test_single_dataset.py
+++ b/tests/data_loaders/test_single_dataset.py
@@ -432,3 +432,62 @@ class TestSingleDataset:
             )
             subset = dataset.subset(variables=["ice_conc"])
             assert subset._normalise is flag
+
+    def test_normalise_date_ranges_adjacent_merge(self) -> None:
+        """Consecutive ranges (next starts the day after) merge into one span."""
+        assert SingleDataset.normalise_date_ranges(
+            [
+                {"start": "2020-01-01", "end": "2020-06-30"},
+                {"start": "2020-07-01", "end": "2020-12-31"},
+            ]
+        ) == [{"start": "2020-01-01", "end": "2020-12-31"}]
+
+    def test_normalise_date_ranges_shared_boundary_merge(self) -> None:
+        """Ranges meeting on the same day merge (treated as consecutive)."""
+        assert SingleDataset.normalise_date_ranges(
+            [
+                {"start": "2020-01-01", "end": "2020-07-01"},
+                {"start": "2020-07-01", "end": "2020-12-31"},
+            ]
+        ) == [{"start": "2020-01-01", "end": "2020-12-31"}]
+
+    def test_normalise_date_ranges_gap_not_merged(self) -> None:
+        """A missing day between ranges leaves them as separate spans."""
+        ranges: list[dict[str, str | None]] = [
+            {"start": "2020-01-01", "end": "2020-06-30"},
+            {"start": "2020-07-02", "end": "2020-12-31"},
+        ]
+        assert SingleDataset.normalise_date_ranges(ranges) == ranges
+
+    def test_normalise_date_ranges_overlap_left_alone(self) -> None:
+        """Overlapping ranges are not merged (and not truncated)."""
+        ranges: list[dict[str, str | None]] = [
+            {"start": "2020-01-01", "end": "2020-12-31"},
+            {"start": "2020-03-01", "end": "2020-06-30"},
+        ]
+        assert SingleDataset.normalise_date_ranges(ranges) == ranges
+
+    def test_normalise_date_ranges_end_none_left_alone(self) -> None:
+        """An open end (None = last date) overlaps a later range, so it is left alone."""
+        ranges: list[dict[str, str | None]] = [
+            {"start": "2020-01-01", "end": None},
+            {"start": "2020-06-01", "end": "2020-09-30"},
+        ]
+        assert SingleDataset.normalise_date_ranges(ranges) == ranges
+
+    def test_normalise_date_ranges_start_none_left_alone(self) -> None:
+        """Two open starts (None = first date) overlap, so they are left alone."""
+        ranges: list[dict[str, str | None]] = [
+            {"start": None, "end": "2020-03-31"},
+            {"start": None, "end": "2020-06-30"},
+        ]
+        assert SingleDataset.normalise_date_ranges(ranges) == ranges
+
+    def test_normalise_date_ranges_open_outer_ends_merge(self) -> None:
+        """Open-beginning + open-ending halves that meet merge to the whole range."""
+        assert SingleDataset.normalise_date_ranges(
+            [
+                {"start": None, "end": "2020-06-30"},
+                {"start": "2020-07-01", "end": None},
+            ]
+        ) == [{"start": None, "end": None}]

--- a/tests/data_loaders/test_single_dataset.py
+++ b/tests/data_loaders/test_single_dataset.py
@@ -185,6 +185,26 @@ class TestSingleDataset:
         with pytest.raises(ValueError, match="cannot reshape array"):
             dataset.get_tchw_slice(dates_as_np[0], 3, check=False)
 
+    def test_touching_ranges_merge_into_one_dataslice(
+        self,
+        mock_dataset: Path,
+        dates_as_str: tuple[str, ...],
+        dates_as_np: tuple[np.datetime64, ...],
+    ) -> None:
+        # a small test of merging touching ranges, described in issue #279.
+        dataset = SingleDataset(
+            name="mock_dataset",
+            input_files=[mock_dataset],
+            date_ranges=[
+                {"start": dates_as_str[0], "end": dates_as_str[1]},
+                {"start": dates_as_str[2], "end": dates_as_str[4]},
+            ],
+        )
+        assert len(dataset.dataslices) == 1
+        assert len(dataset) == 5
+        result = dataset.get_tchw_slice(dates_as_np[0], 3, check=False)
+        assert result.shape == (3, 3, 2, 2)
+
     def test_get_tchw_with_missing_dates(
         self,
         mock_dataset_missing_dates: Path,


### PR DESCRIPTION
  Closes #279

  Testing
  - pytest tests/data_loaders/ on an Isambard GH200 node: 48 passed — the new
    regression test, the full single_dataset suite, and the integration layer
    (combined_dataset, common_data_module). No regressions.
  - pre-commit: all hooks pass.
  - mypy: no issues.

  Scope: unit/integration level against the mock-dataset fixture; no end-to-end
  training run on real data (not needed for this change). The change is confined to the date-range-merge
  logic in the data loader.