### PR TITLE
Add how to run examples

### DIFF
--- a/docs/src/how-to/evaluate.md
+++ b/docs/src/how-to/evaluate.md
@@ -32,7 +32,7 @@ uv run imp evaluate --config-name <your-name>.local --checkpoint PATH_TO_CHECKPO
 
 ### Enabling visualisations
 
-By default, visualisations are enabled (see `evaluate/callbacks/plotting.yaml`). To disable them, set `make_static_plots` and `make_video_plots` to `false` in your local config:
+By default, all visualisations are enabled (see `icenet_mp/config/evaluate/callbacks/plotting.yaml`). To disable forecast plots, set `make_static_plots` and `make_video_plots` to `false` in your local config:
 
 ```yaml
 evaluate:
@@ -42,16 +42,14 @@ evaluate:
       make_video_plots: false
 ```
 
-To enable plots of the raw input data alongside the forecasts, add:
+Plots of the raw input data are also enabled by default. To disable them, set:
 
 ```yaml
 evaluate:
   callbacks:
     plotting:
-      make_input_plots: true
+      make_input_plots: false
 ```
-
-Output directories, styling, and animation parameters are set under `evaluate.callbacks.plotting.plot_spec` and can be overridden at the command line.
 
 ## 4. Check results in W&B
 
@@ -63,4 +61,4 @@ Once evaluation completes, the run appears in the `turing-seaice` W&B project at
 | `output_video` | Animated forecast output. |
 | `input_static` | Static images of the raw input data (if `make_input_plots: true`). |
 | `input_video` | Animated raw input data (if `make_input_plots: true`). |
-| `Custom Charts` | Per-forecast-day metrics, allowing skill to be assessed at longer lead times |
+| `Custom Charts` | Per-forecast-day metrics, allowing skill to be assessed at longer lead times. |

--- a/docs/src/how-to/evaluate.md
+++ b/docs/src/how-to/evaluate.md
@@ -1,0 +1,66 @@
+# Run an evaluation job
+
+This guide walks through running an evaluation on a trained checkpoint: launching the job, enabling visualisations, and finding the outputs.
+
+## Prerequisites
+
+Make sure IceNet-MP is [installed](../user-guide/installation.md) and that you have a trained checkpoint — either from a [training run](run-training.md) or downloaded from shared storage.
+
+## 1. Get a checkpoint
+
+### From a training run
+
+Checkpoints are saved to `${BASE_DIR}/training/wandb/run-<date>-<id>/checkpoints/<name>.ckpt` after training. Pick the checkpoint you want to evaluate.
+
+### From shared storage (HPC)
+
+Pre-trained checkpoints are available on Baskerville, DAWN, and Isambard-AI.
+Ask a team member for the path.
+
+## 2. Create a local config
+
+If you do not already have a local config from a training run, create one at `icenet_mp/config/<your-name>.local.yaml`.
+See [Run a training job — Create a local config](run-training.md#2-create-a-local-config) for details.
+
+## 3. Run evaluate
+
+See the [`evaluate` command reference](../user-guide/commands.md#evaluate) for full option details, then run:
+
+```bash
+uv run imp evaluate --config-name <your-name>.local --checkpoint PATH_TO_CHECKPOINT
+```
+
+### Enabling visualisations
+
+By default, visualisations are enabled (see `evaluate/callbacks/plotting.yaml`). To disable them, set `make_static_plots` and `make_video_plots` to `false` in your local config:
+
+```yaml
+evaluate:
+  callbacks:
+    plotting:
+      make_static_plots: false
+      make_video_plots: false
+```
+
+To enable plots of the raw input data alongside the forecasts, add:
+
+```yaml
+evaluate:
+  callbacks:
+    plotting:
+      make_input_plots: true
+```
+
+Output directories, styling, and animation parameters are set under `evaluate.callbacks.plotting.plot_spec` and can be overridden at the command line.
+
+## 4. Check results in W&B
+
+Once evaluation completes, the run appears in the `turing-seaice` W&B project at [wandb.ai](https://wandb.ai).
+
+| Key | Contents |
+|-----|----------|
+| `output_static` | Static images of forecast output. |
+| `output_video` | Animated forecast output. |
+| `input_static` | Static images of the raw input data (if `make_input_plots: true`). |
+| `input_video` | Animated raw input data (if `make_input_plots: true`). |
+| `Custom Charts` | Per-forecast-day metrics, allowing skill to be assessed at longer lead times |

--- a/docs/src/how-to/evaluate.md
+++ b/docs/src/how-to/evaluate.md
@@ -4,7 +4,7 @@ This guide walks through running an evaluation on a trained checkpoint: launchin
 
 ## Prerequisites
 
-Make sure IceNet-MP is [installed](../user-guide/installation.md) and that you have a trained checkpoint — either from a [training run](run-training.md) or downloaded from shared storage.
+Make sure IceNet-MP is [installed](../user-guide/installation.md) and that you have a trained checkpoint — either from a [training run](train.md) or downloaded from shared storage.
 
 ## 1. Get a checkpoint
 
@@ -20,7 +20,7 @@ Ask a team member for the path.
 ## 2. Create a local config
 
 If you do not already have a local config from a training run, create one at `icenet_mp/config/<your-name>.local.yaml`.
-See [Run a training job — Create a local config](run-training.md#2-create-a-local-config) for details.
+See [Train a model — Create a local config](train.md#2-create-a-local-config) for details.
 
 ## 3. Run evaluate
 

--- a/docs/src/how-to/evaluate.md
+++ b/docs/src/how-to/evaluate.md
@@ -53,7 +53,7 @@ evaluate:
 
 ## 4. Check results in W&B
 
-Once evaluation completes, the run appears in the `turing-seaice` W&B project at [wandb.ai](https://wandb.ai).
+Once evaluation completes, the run appears in the W&B project `evaluate` under the `turing-seaice` entity at [wandb.ai](https://wandb.ai).
 
 | Key | Contents |
 |-----|----------|

--- a/docs/src/how-to/train.md
+++ b/docs/src/how-to/train.md
@@ -62,6 +62,21 @@ base_path: /path/to/your/data
 
 See [Configuration](../user-guide/configuration.md) for how to switch datasets or override model parameters.
 
+### Reusing a config from a previous W&B run
+
+To reproduce or extend a prior run, download its saved config from the W&B run page under **Files > `model_config.yaml`** and place it at `icenet_mp/config/<your-name>.local.yaml`.
+Make sure that the `defaults` block points at the appropriate base config for your machine:
+
+```yaml
+defaults:
+  - base_isambardai   # or base_baskerville, base_dawn, base.local etc.
+  - _self_
+
+# ... rest of the downloaded config ...
+```
+
+If you are running locally, ensure that `base_path` is set as well.
+
 ## 3. Run training
 
 ```bash

--- a/docs/src/how-to/train.md
+++ b/docs/src/how-to/train.md
@@ -114,7 +114,7 @@ Pass this path to `evaluate` to assess the trained model.
 
 ## 4. Check results in W&B
 
-Once training starts, the run appears in the `turing-seaice` W&B project at [wandb.ai](https://wandb.ai).
+Once training starts, the run appears in the W&B project `train` under the `turing-seaice` entity at [wandb.ai](https://wandb.ai).
 
 ### What to look for
 

--- a/docs/src/how-to/train.md
+++ b/docs/src/how-to/train.md
@@ -1,13 +1,12 @@
 # Train a model
 
+This guide walks through an end-to-end training run: getting data, creating a local config, launching training, and inspecting results in Weights & Biases.
 Single-stage training trains the full model end-to-end in one pass.
 It is the default and works for all model architectures.
 
-```bash
-uv run imp train
-```
-
 ## Prerequisites
+
+Make sure IceNet-MP is [installed](../user-guide/installation.md) before continuing.
 
 You will need a [Weights & Biases account](https://docs.wandb.ai/models/quickstart).
 Generate an API key, then authenticate before running any training command:
@@ -15,6 +14,58 @@ Generate an API key, then authenticate before running any training command:
 ```bash
 export WANDB_API_KEY=<your_api_key>
 wandb login
+```
+
+## 1. Get data
+
+### Using pre-downloaded data (HPC)
+
+If you are working on Baskerville, DAWN, or Isambard-AI, the datasets are already available on shared storage. Use the appropriate base config and skip ahead to [step 2](#2-create-a-local-config):
+
+```yaml
+defaults:
+  - base_isambardai   # or base_baskerville or base_dawn
+  - _self_
+```
+
+### Downloading data locally
+
+See the [`datasets create` command reference](../user-guide/commands.md#datasets-create) for prerequisites and usage.
+
+## 2. Create a local config
+
+Create a file at `icenet_mp/config/<your-name>.local.yaml`. The base config you inherit from depends on where you are running.
+
+### On Isambard-AI
+
+Inherit from `base_isambardai`, which already points to the shared data storage:
+
+```yaml
+defaults:
+  - base_isambardai
+  - _self_
+```
+
+Use `base_baskerville` or `base_dawn` instead if you are on one of those systems.
+
+### On a local machine
+
+Inherit from `base` and set `base_path` to the directory where you downloaded your data:
+
+```yaml
+defaults:
+  - base
+  - _self_
+
+base_path: /path/to/your/data
+```
+
+See [Configuration](../user-guide/configuration.md) for how to switch datasets or override model parameters.
+
+## 3. Run training
+
+```bash
+uv run imp train --config-name <your-name>.local
 ```
 
 ## Configuring training
@@ -45,6 +96,22 @@ ${BASE_DIR}/training/wandb/run-<date>-<id>/checkpoints/
 
 where `BASE_DIR` is the `base_path` defined in your local config.
 Pass this path to `evaluate` to assess the trained model.
+
+## 4. Check results in W&B
+
+Once training starts, the run appears in the `turing-seaice` W&B project at [wandb.ai](https://wandb.ai).
+
+### What to look for
+
+| Panel | What it shows |
+|-------|---------------|
+| `train_loss` / `validation_loss` | Loss per epoch — watch for validation loss converging or diverging from training loss. |
+| `train_{metric}_mean` / `validation_{metric}_mean` | Per-epoch mean of each metric (e.g. SIE error, IceNet accuracy). |
+| `{metric}_per_forecast_day` | Metric broken down by forecast lead day, logged at the end of the run. Useful for diagnosing where skill drops at longer horizons. |
+
+### Comparing runs
+
+Use the W&B workspace to overlay multiple runs on the same chart, or group runs by config keys (e.g. `model`, `data`) to understand what drives performance differences across experiments.
 
 ## Multistage training
 

--- a/icenet_mp/model_service.py
+++ b/icenet_mp/model_service.py
@@ -315,7 +315,9 @@ class ModelService:
             model_config_path.parent.mkdir(parents=True, exist_ok=True)
             OmegaConf.save(self.config, model_config_path)
             if wandb_run := get_wandb_run(trainer):
-                wandb_run.save(model_config_path, base_path=model_config_path.parent)
+                wandb_run.save(
+                    model_config_path, base_path=model_config_path.parent, policy="now"
+                )
 
         # Additional configuration for callbacks
         for callback in cast("list[Callback]", trainer.callbacks):  # type: ignore[attr-defined]

--- a/zensical.toml
+++ b/zensical.toml
@@ -19,7 +19,8 @@ nav = [
         { "Add a model" = "how-to/add-a-model.md" },
         { "Add a processor" = "how-to/add-a-processor.md" },
         { "Train a model" = "how-to/train.md" },
-        { "Run multistage training" = "how-to/train-multistage.md" },
+        { "Train a model in multiple stages" = "how-to/train-multistage.md" },
+        { "Evaluate a model" = "how-to/evaluate.md" },
     ] },
     { "API Reference" = [
         { "Overview" = "api/index.md" },


### PR DESCRIPTION
## New How-to section entries

- Run a training job end-to-end walkthrough:
  - getting data 
  - creating a local config
  - launching training
  - what to look for in the W&B run

- Run an evaluation job
  - finding a checkpoint
  - creating a config
  - running evaluate
  - enabling/disabling visualisations
  - reading the W&B outputs.

Both pages link to the existing reference docs (commands.md, configuration.md) rather than duplicating them.

## Fix model_config upload

`model_config.yaml` wasn't uploading for jobs that did not run to completion. By switching to `policy="now"`, the config should be uploaded at the start of the job and therefore be available on W&B even for failed jobs.

Closes #344 