### PR TITLE
Reduce wandb run size

### DIFF
--- a/icenet_mp/callbacks/plotting_callback.py
+++ b/icenet_mp/callbacks/plotting_callback.py
@@ -80,7 +80,7 @@ class PlottingCallback(Callback):
             self.cached_dataloader_idx_ = dataloader_idx
 
     def is_sample_batch(self, batch_idx: int, total_batches: float) -> bool:
-        """Return True if batch_idx is one of frequency_samples equally-spaced targets."""
+        """Return True if batch_idx is one of frequency_number equally-spaced targets."""
         if (
             self.frequency_number <= 0
             or not isinstance(total_batches, int)

--- a/icenet_mp/callbacks/plotting_callback.py
+++ b/icenet_mp/callbacks/plotting_callback.py
@@ -41,7 +41,7 @@ class PlottingCallback(Callback):
             frequency: A dictionary specifying how often to make plots, with keys:
                 batch (plot every N batches)
                 epoch (plot every N epochs)
-                number (plot N sample batches evenly spaced across the dataset)
+                number (plot N sample batches evenly spaced across the epoch)
             make_input_plots: Whether to plot the raw inputs.
             make_static_plots: Whether to create static plots.
             make_video_plots: Whether to create video plots.

--- a/icenet_mp/callbacks/plotting_callback.py
+++ b/icenet_mp/callbacks/plotting_callback.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from collections.abc import Mapping, Sequence
 from typing import Any
 
@@ -79,15 +80,15 @@ class PlottingCallback(Callback):
             self.cached_batch_idx_ = batch_idx
             self.cached_dataloader_idx_ = dataloader_idx
 
-    def is_sample_batch(self, batch_idx: int, total_batches: float) -> bool:
+    def is_sample_batch(self, batch_idx: int, total_batches: int | float) -> bool:  # noqa: PYI041
         """Return True if batch_idx is one of frequency_number equally-spaced targets."""
         if (
             self.frequency_number <= 0
-            or not isinstance(total_batches, int)
+            or not math.isfinite(total_batches)
             or total_batches <= 0
         ):
             return False
-        n = min(self.frequency_number, total_batches)
+        n = int(min(self.frequency_number, total_batches))
         if n == 1:
             return batch_idx == total_batches - 1
         targets = {round(i * (total_batches - 1) / (n - 1)) for i in range(n)}

--- a/icenet_mp/callbacks/plotting_callback.py
+++ b/icenet_mp/callbacks/plotting_callback.py
@@ -38,7 +38,10 @@ class PlottingCallback(Callback):
 
         Args:
             base_path: Base path for finding land masks.
-            frequency: A dictionary specifying how often to make plots, with keys "batch" and/or "epoch".
+            frequency: A dictionary specifying how often to make plots, with keys:
+                batch (plot every N batches)
+                epoch (plot every N epochs)
+                number (plot N sample batches evenly spaced across the dataset)
             make_input_plots: Whether to plot the raw inputs.
             make_static_plots: Whether to create static plots.
             make_video_plots: Whether to create video plots.
@@ -49,6 +52,7 @@ class PlottingCallback(Callback):
         super().__init__()
         self.frequency_batch = int((frequency or {}).get("batch", -1))
         self.frequency_epoch = int((frequency or {}).get("epoch", -1))
+        self.frequency_number = int((frequency or {}).get("number", -1))
         self.make_input_plots = make_input_plots
         self.make_static_plots = make_static_plots
         self.make_video_plots = make_video_plots
@@ -74,6 +78,20 @@ class PlottingCallback(Callback):
             self.cached_outputs_ = ModelStepOutput(**outputs)
             self.cached_batch_idx_ = batch_idx
             self.cached_dataloader_idx_ = dataloader_idx
+
+    def is_sample_batch(self, batch_idx: int, total_batches: float) -> bool:
+        """Return True if batch_idx is one of frequency_samples equally-spaced targets."""
+        if (
+            self.frequency_number <= 0
+            or not isinstance(total_batches, int)
+            or total_batches <= 0
+        ):
+            return False
+        n = min(self.frequency_number, total_batches)
+        if n == 1:
+            return batch_idx == total_batches - 1
+        targets = {round(i * (total_batches - 1) / (n - 1)) for i in range(n)}
+        return batch_idx in targets
 
     def load_dataset(
         self, dataloader: DataLoader | list[DataLoader] | None
@@ -172,13 +190,16 @@ class PlottingCallback(Callback):
         # Check whether this is a batch we want to plot based on the frequency settings
         is_per_epoch = trainer.is_last_batch
         is_per_batch = self.frequency_batch > 0 and not batch_idx % self.frequency_batch
+        is_sampled_batch = self.is_sample_batch(
+            batch_idx, trainer.num_test_batches[dataloader_idx]
+        )
 
         # Cache if this is a batch we want to plot
-        if is_per_epoch or is_per_batch:
+        if is_per_epoch or is_per_batch or is_sampled_batch:
             self.cache_batch(batch_idx, dataloader_idx, outputs)
 
         # If this is a selected batch then we will plot here
-        if is_per_batch:
+        if is_per_batch or is_sampled_batch:
             # Load the dataset
             if not (ds_tuple := self.load_dataset(trainer.test_dataloaders)):
                 logger.warning("Could not load dataset, skipping plotting.")
@@ -218,13 +239,16 @@ class PlottingCallback(Callback):
         # Check whether this is a batch we want to plot based on the frequency settings
         is_per_epoch = trainer.fit_loop.epoch_loop.val_loop.batch_progress.is_last_batch
         is_per_batch = self.frequency_batch > 0 and not batch_idx % self.frequency_batch
+        is_sampled_batch = self.is_sample_batch(
+            batch_idx, trainer.num_val_batches[dataloader_idx]
+        )
 
         # Cache if this is a batch we want to plot
-        if is_per_epoch or is_per_batch:
+        if is_per_epoch or is_per_batch or is_sampled_batch:
             self.cache_batch(batch_idx, dataloader_idx, outputs)
 
         # If this is a selected batch then we will plot here
-        if is_per_batch:
+        if is_per_batch or is_sampled_batch:
             # Load the dataset
             if not (ds_tuple := self.load_dataset(trainer.val_dataloaders)):
                 logger.warning("Could not load dataset, skipping plotting.")

--- a/icenet_mp/config/evaluate/callbacks/plotting.yaml
+++ b/icenet_mp/config/evaluate/callbacks/plotting.yaml
@@ -1,7 +1,7 @@
 plotting:
   _target_: icenet_mp.callbacks.PlottingCallback
   frequency:
-    batch: 5  # plot every 5 evaluation batches
+    number: 3 # plot exactly 3 sample batches equally space in the date range
   make_input_plots: true
   make_static_plots: true
   make_video_plots: true

--- a/icenet_mp/config/evaluate/callbacks/plotting.yaml
+++ b/icenet_mp/config/evaluate/callbacks/plotting.yaml
@@ -1,7 +1,7 @@
 plotting:
   _target_: icenet_mp.callbacks.PlottingCallback
   frequency:
-    number: 3 # plot exactly 3 sample batches equally space in the date range
+    number: 3 # plot exactly 3 batches equally spaced across the epoch
   make_input_plots: true
   make_static_plots: true
   make_video_plots: true

--- a/icenet_mp/config/evaluate/callbacks/plotting.yaml
+++ b/icenet_mp/config/evaluate/callbacks/plotting.yaml
@@ -2,7 +2,7 @@ plotting:
   _target_: icenet_mp.callbacks.PlottingCallback
   frequency:
     number: 3 # plot exactly 3 batches equally spaced across the epoch
-  make_input_plots: true
+  make_input_plots: false
   make_static_plots: true
   make_video_plots: true
   base_path: ${base_path}

--- a/icenet_mp/config/train/callbacks/device_stats.yaml
+++ b/icenet_mp/config/train/callbacks/device_stats.yaml
@@ -1,2 +1,0 @@
-device_stats:
-  _target_: lightning.pytorch.callbacks.DeviceStatsMonitor

--- a/icenet_mp/config/train/callbacks/plotting.yaml
+++ b/icenet_mp/config/train/callbacks/plotting.yaml
@@ -1,7 +1,7 @@
 plotting:
   _target_: icenet_mp.callbacks.PlottingCallback
   frequency:
-    number: 3 # plot exactly 3 sample batches equally space in the date range
+    number: 3 # plot exactly 3 batches equally spaced across the epoch
   make_input_plots: false
   make_static_plots: true
   make_video_plots: false

--- a/icenet_mp/config/train/callbacks/plotting.yaml
+++ b/icenet_mp/config/train/callbacks/plotting.yaml
@@ -4,5 +4,5 @@ plotting:
     batch: 5  # plot every 5 validation batches
   make_input_plots: false
   make_static_plots: true
-  make_video_plots: true
+  make_video_plots: false
   base_path: ${base_path}

--- a/icenet_mp/config/train/callbacks/plotting.yaml
+++ b/icenet_mp/config/train/callbacks/plotting.yaml
@@ -1,7 +1,7 @@
 plotting:
   _target_: icenet_mp.callbacks.PlottingCallback
   frequency:
-    batch: 5  # plot every 5 validation batches
+    number: 3 # plot exactly 3 sample batches equally space in the date range
   make_input_plots: false
   make_static_plots: true
   make_video_plots: false

--- a/icenet_mp/config/train/default.yaml
+++ b/icenet_mp/config/train/default.yaml
@@ -1,6 +1,5 @@
 defaults:
   - callbacks:
-    - device_stats
     - ema_weight_averaging
     - learning_rate
     - metric_summary

--- a/icenet_mp/config/train/persistence.yaml
+++ b/icenet_mp/config/train/persistence.yaml
@@ -1,7 +1,6 @@
 defaults:
   - default
   - override callbacks:
-    - device_stats
     - unconditional_checkpoint
   - _self_
 


### PR DESCRIPTION
Reduce the size of each W&B run.

- Disable video plots for training runs
- Disable input static/video for evaluate runs
- Plot a fixed number of samples (default 3) rather than a frequency
- Drop DeviceStatsMonitor which isn't being used

## Before
[upbeat-puddle-988](https://wandb.ai/turing-seaice/train/runs/apobjdbb)
<img width="1846" height="487" alt="Screenshot 2026-07-02 at 17 08 34" src="https://github.com/user-attachments/assets/8a4a5b67-c583-44ba-bc4d-0440b3b952c7" />

## After
[crimson-star-990](https://wandb.ai/turing-seaice/train/runs/9ih14mwi)
<img width="1845" height="488" alt="Screenshot 2026-07-02 at 17 20 38" src="https://github.com/user-attachments/assets/9afa39c9-3971-4f19-942c-a8449baab2a9" />

9MB => 6MB (a 1/3 reduction).
