### PR TITLE
Fix latent encoding for SSMIS

### DIFF
--- a/icenet_mp/config/data/datasets/full_weathernorth_era5_25p0km_1979_2025_24h_v3.yaml
+++ b/icenet_mp/config/data/datasets/full_weathernorth_era5_25p0km_1979_2025_24h_v3.yaml
@@ -18,7 +18,7 @@ full-weathernorth-era5-25p0km-1979-2025-24h-v3:
             class: ea
             expver: "0001"
             grid: "0.25 / 0.25"
-            area: "90/-180/20/180"  # northern hemisphere
+            area: "90/-180/15/180"  # northern hemisphere
             levtype: sfc
             param:
             - 2t # 2-metre air temperature
@@ -31,7 +31,7 @@ full-weathernorth-era5-25p0km-1979-2025-24h-v3:
             class: ea
             expver: "0001"
             grid: "0.25 / 0.25"
-            area: "90/-180/20/180"  # northern hemisphere
+            area: "90/-180/15/180"  # northern hemisphere
             level:
             - 10 # hPa
             - 250 # hPa

--- a/icenet_mp/config/data/datasets/full_weathersouth_era5_25p0km_1979_2025_24h_v3.yaml
+++ b/icenet_mp/config/data/datasets/full_weathersouth_era5_25p0km_1979_2025_24h_v3.yaml
@@ -18,7 +18,7 @@ full-weathersouth-era5-25p0km-1979-2025-24h-v3:
             class: ea
             expver: "0001"
             grid: "0.25 / 0.25"
-            area: "-20/-180/-90/180"  # southern hemisphere
+            area: "-15/-180/-90/180"  # southern hemisphere
             levtype: sfc
             param:
             - 2t # 2-metre air temperature
@@ -31,7 +31,7 @@ full-weathersouth-era5-25p0km-1979-2025-24h-v3:
             class: ea
             expver: "0001"
             grid: "0.25 / 0.25"
-            area: "-20/-180/-90/180"  # southern hemisphere
+            area: "-15/-180/-90/180"  # southern hemisphere
             level:
             - 10 # hPa
             - 250 # hPa

--- a/icenet_mp/config/data/datasets/samp_weathernorth_era5_25p0km_2017_2019_24h_v3.yaml
+++ b/icenet_mp/config/data/datasets/samp_weathernorth_era5_25p0km_2017_2019_24h_v3.yaml
@@ -18,7 +18,7 @@ samp-weathernorth-era5-25p0km-2017-2019-24h-v3:
             class: ea
             expver: "0001"
             grid: "0.25 / 0.25"
-            area: "90/-180/20/180"  # northern hemisphere
+            area: "90/-180/15/180"  # northern hemisphere
             levtype: sfc
             param:
             - 2t # 2-metre air temperature
@@ -31,7 +31,7 @@ samp-weathernorth-era5-25p0km-2017-2019-24h-v3:
             class: ea
             expver: "0001"
             grid: "0.25 / 0.25"
-            area: "90/-180/20/180"  # northern hemisphere
+            area: "90/-180/15/180"  # northern hemisphere
             level:
             - 10 # hPa
             - 250 # hPa

--- a/icenet_mp/config/data/datasets/samp_weathersouth_era5_25p0km_2017_2019_24h_v3.yaml
+++ b/icenet_mp/config/data/datasets/samp_weathersouth_era5_25p0km_2017_2019_24h_v3.yaml
@@ -15,7 +15,7 @@ samp-weathersouth-era5-25p0km-2017-2019-24h-v3:
       - join:
         - mars:
             use_cdsapi_dataset: "reanalysis-era5-complete"
-            area: "-20/-180/-90/180"  # southern hemisphere
+            area: "-15/-180/-90/180"  # southern hemisphere
             grid: "0.25 / 0.25"
             levtype: sfc
             param:
@@ -26,7 +26,7 @@ samp-weathersouth-era5-25p0km-2017-2019-24h-v3:
             - msl # Sea level pressure
         - mars:
             use_cdsapi_dataset: "reanalysis-era5-complete"
-            area: "-20/-180/-90/180"  # southern hemisphere
+            area: "-15/-180/-90/180"  # southern hemisphere
             grid: "0.25 / 0.25"
             level:
             - 10 # hPa

--- a/icenet_mp/data_loaders/common_data_module.py
+++ b/icenet_mp/data_loaders/common_data_module.py
@@ -46,10 +46,8 @@ class CommonDataModule(LightningDataModule):
         if self.target_group_name not in self.dataset_groups:
             msg = f"Could not find prediction target {self.target_group_name}."
             raise ValueError(msg)
-
-        # Set target variables for prediction, defaulting to the entire target dataset.
-        self.target_variables: list[str] = config["predict"]["target"].get(
-            "variables", self.variable_names[self.target_group_name]
+        self._target_variables: list[str] = config["predict"]["target"].get(
+            "variables", []
         )
 
         # Set periods for train, validation, and test
@@ -127,6 +125,13 @@ class CommonDataModule(LightningDataModule):
             .subset(variables=self.target_variables)
             .space
         )
+
+    @cached_property
+    def target_variables(self) -> list[str]:
+        """Return the names of the variables to predict."""
+        if self._target_variables:
+            return self._target_variables
+        return self.variable_names[self.target_group_name]
 
     @cached_property
     def variable_names(self) -> dict[str, list[str]]:

--- a/icenet_mp/data_loaders/common_data_module.py
+++ b/icenet_mp/data_loaders/common_data_module.py
@@ -46,8 +46,10 @@ class CommonDataModule(LightningDataModule):
         if self.target_group_name not in self.dataset_groups:
             msg = f"Could not find prediction target {self.target_group_name}."
             raise ValueError(msg)
+
+        # Set target variables for prediction, defaulting to the entire target dataset.
         self.target_variables: list[str] = config["predict"]["target"].get(
-            "variables", []
+            "variables", self.variable_names[self.target_group_name]
         )
 
         # Set periods for train, validation, and test

--- a/icenet_mp/model_service.py
+++ b/icenet_mp/model_service.py
@@ -433,13 +433,9 @@ class ModelService:
         checkpoint_dir: Path | None = None,
     ) -> DecoderStage:
         """Train a decoder on the combined latent space of all frozen encoders."""
-        target_variables = (
-            self.data_module.target_variables
-            or self.data_module.variable_names[self.data_module.target_group_name]
-        )
         target_variable_indices = [
             self.data_module.variable_names[self.data_module.target_group_name].index(v)
-            for v in target_variables
+            for v in self.data_module.target_variables
         ]
         if checkpoint_dir is not None and (
             matches := sorted(checkpoint_dir.glob("decoder.epoch=*-step=*.ckpt"))

--- a/icenet_mp/model_service.py
+++ b/icenet_mp/model_service.py
@@ -183,7 +183,7 @@ class ModelService:
             training state (e.g. ``trainer.current_epoch``, ``trainer.global_step``).
 
         """
-        log.info("Configuring model for %s.", job_stage or "training")
+        log.info("Configuring fitting for %s.", job_stage or "training")
         current_model = model or self.model
         current_model.optimizer_cfg = config["optimizer"]
         current_model.scheduler_cfg = config["scheduler"]
@@ -461,6 +461,11 @@ class ModelService:
             target_dataset_name=self.data_module.target_group_name,
             target_variable_indices=target_variable_indices,
         )
+        log.info(
+            "Training decoder: latent %s -> output %s",
+            decoder_model.decoder.data_space_in.chw,
+            decoder_model.decoder.data_space_out.chw,
+        )
         trainer = self._fit(model=decoder_model, config=config, job_stage="decoder")
         self._save_checkpoint(trainer, "decoder")
         return decoder_model
@@ -477,14 +482,16 @@ class ModelService:
         encoder_models = []
         for encoder in [*self.model.encoders, self.model.target_encoder]:
             # The target encoder is named "target" but needs to load data from the real
-            # corresponding underlying dataset. We cannot simply name the target encoder
-            # after the underlying dataset because we want to train a separate encoder
-            # on this.
-            dataset_name = (
-                self.data_module.target_group_name
-                if encoder is self.model.target_encoder
-                else encoder.name
-            )
+            # corresponding underlying dataset. However, we need to construct a custom
+            # DataSpace since we only want to consider the selected target variables,
+            # not the full dataset.
+            if encoder is self.model.target_encoder:
+                dataset_name = self.data_module.target_group_name
+                channel_names = self.data_module.target_variables
+            else:
+                dataset_name = encoder.name
+                channel_names = self.data_module.variable_names[dataset_name]
+
             if checkpoint_dir is not None and (
                 matches := sorted(
                     checkpoint_dir.glob(f"encoder-{encoder.name}.epoch=*-step=*.ckpt")
@@ -508,11 +515,18 @@ class ModelService:
                 continue
 
             encoder_model = EncoderStage.from_template(
-                channel_names=self.data_module.variable_names[dataset_name],
-                dataset=dataset_name,
+                channel_names=channel_names,
+                data_space_in=encoder.data_space_in,
+                dataset=encoder.name,
                 decoder=self.config["model"]["decoder"],
                 encoder=self.config["model"]["encoders"][dataset_name],
                 template=self.model,
+            )
+            log.info(
+                "Training encoder-%s: input %s -> latent %s",
+                encoder.name,
+                encoder_model.encoder.data_space_in.chw,
+                encoder_model.encoder.data_space_out.chw,
             )
             trainer = self._fit(
                 model=encoder_model,
@@ -570,6 +584,13 @@ class ModelService:
             processor=self.config["model"]["processor"],
             decoder_model=decoder_model,
             target_encoder=target_encoder,
+        )
+        log.info(
+            "Training processor: (%d, %d, %d, %d) -> (%d, %d, %d, %d)",
+            processor_model.processor.n_history_steps,
+            *processor_model.processor.data_space.chw,
+            processor_model.processor.n_forecast_steps,
+            *processor_model.processor.data_space.chw,
         )
         trainer = self._fit(model=processor_model, config=config, job_stage="processor")
         self._save_checkpoint(trainer, "processor")

--- a/icenet_mp/model_service.py
+++ b/icenet_mp/model_service.py
@@ -480,6 +480,15 @@ class ModelService:
             raise TypeError(msg)
         encoder_models = []
         for encoder in [*self.model.encoders, self.model.target_encoder]:
+            # The target encoder is named "target" but needs to load data from the real
+            # corresponding underlying dataset. We cannot simply name the target encoder
+            # after the underlying dataset because we want to train a separate encoder
+            # on this.
+            dataset_name = (
+                self.data_module.target_group_name
+                if encoder is self.model.target_encoder
+                else encoder.name
+            )
             if checkpoint_dir is not None and (
                 matches := sorted(
                     checkpoint_dir.glob(f"encoder-{encoder.name}.epoch=*-step=*.ckpt")
@@ -503,10 +512,10 @@ class ModelService:
                 continue
 
             encoder_model = EncoderStage.from_template(
-                channel_names=self.data_module.variable_names[encoder.name],
-                dataset=encoder.name,
+                channel_names=self.data_module.variable_names[dataset_name],
+                dataset=dataset_name,
                 decoder=self.config["model"]["decoder"],
-                encoder=self.config["model"]["encoders"][encoder.name],
+                encoder=self.config["model"]["encoders"][dataset_name],
                 template=self.model,
             )
             trainer = self._fit(

--- a/icenet_mp/model_service.py
+++ b/icenet_mp/model_service.py
@@ -477,7 +477,7 @@ class ModelService:
             )
             raise TypeError(msg)
         encoder_models = []
-        for encoder in self.model.encoders:
+        for encoder in [*self.model.encoders, self.model.target_encoder]:
             if checkpoint_dir is not None and (
                 matches := sorted(
                     checkpoint_dir.glob(f"encoder-{encoder.name}.epoch=*-step=*.ckpt")

--- a/icenet_mp/model_service.py
+++ b/icenet_mp/model_service.py
@@ -402,6 +402,7 @@ class ModelService:
             config=self._merged_config("encoders"),
             checkpoint_dir=checkpoint_dir,
         )
+        target_encoder = trained_encoders.pop()  # the decoder must not use this
 
         log.info("Preparing to train the decoder...")
         trained_decoder = self.train_stage_decoder(
@@ -415,6 +416,7 @@ class ModelService:
             trained_decoder,
             config=self._merged_config("processor"),
             checkpoint_dir=checkpoint_dir,
+            target_encoder=target_encoder,
         )
 
         log.info("Preparing to finetune...")
@@ -536,6 +538,7 @@ class ModelService:
     def train_stage_processor(
         self,
         decoder_model: DecoderStage,
+        target_encoder: EncoderStage,
         *,
         config: DictConfig,
         checkpoint_dir: Path | None = None,
@@ -555,11 +558,13 @@ class ModelService:
                 weights_only=False,
                 processor=self.config["model"]["processor"],
                 decoder_model=decoder_model,
+                target_encoder=target_encoder,
             )
 
         processor_model = ProcessorStage.from_template(
             processor=self.config["model"]["processor"],
             decoder_model=decoder_model,
+            target_encoder=target_encoder,
         )
         trainer = self._fit(model=processor_model, config=config, job_stage="processor")
         self._save_checkpoint(trainer, "processor")

--- a/icenet_mp/models/encode_process_decode.py
+++ b/icenet_mp/models/encode_process_decode.py
@@ -43,6 +43,20 @@ class EncodeProcessDecode(BaseModel):
             msg = f"Error instantiating encoders: {exc}. Please ensure that encoders are specified for all input spaces: {self.input_spaces}"
             raise ValueError(msg) from exc
 
+        # Add an additional encoder that encodes the target dataset into latent space
+        # This will be used by any processors that need to compute latent space losses.
+        self.target_encoder: BaseEncoder = hydra.utils.instantiate(
+            encoders[self.output_space.name],
+            data_space_in=DataSpace(
+                name="target",
+                channels=self.output_space.channels,
+                shape=self.output_space.shape,
+            ),
+            latent_space=encoders["latent_space"],
+            latitudes_fn=self.latitudes_fn,
+            longitudes_fn=self.longitudes_fn,
+        )
+
         # We have to explicitly register each encoder as list[Module] will not be
         # automatically picked up by PyTorch
         for input_space, module in zip(self.input_spaces, self.encoders, strict=True):

--- a/icenet_mp/models/encode_process_decode.py
+++ b/icenet_mp/models/encode_process_decode.py
@@ -40,22 +40,33 @@ class EncodeProcessDecode(BaseModel):
                 for input_space in self.input_spaces
             ]
         except KeyError as exc:
-            msg = f"Error instantiating encoders: {exc}. Please ensure that encoders are specified for all input spaces: {self.input_spaces}"
+            msg = (
+                f"Error instantiating encoders: {exc}. Please ensure that encoders are "
+                f"specified for all input spaces: {self.input_spaces}"
+            )
             raise ValueError(msg) from exc
 
         # Add an additional encoder that encodes the target dataset into latent space
         # This will be used by any processors that need to compute latent space losses.
-        self.target_encoder: BaseEncoder = hydra.utils.instantiate(
-            encoders[self.output_space.name],
-            data_space_in=DataSpace(
-                name="target",
-                channels=self.output_space.channels,
-                shape=self.output_space.shape,
-            ),
-            latent_space=encoders["latent_space"],
-            latitudes_fn=self.latitudes_fn,
-            longitudes_fn=self.longitudes_fn,
-        )
+        try:
+            self.target_encoder: BaseEncoder = hydra.utils.instantiate(
+                encoders[self.output_space.name],
+                data_space_in=DataSpace(
+                    name="target",
+                    channels=self.output_space.channels,
+                    shape=self.output_space.shape,
+                ),
+                latent_space=encoders["latent_space"],
+                latitudes_fn=self.latitudes_fn,
+                longitudes_fn=self.longitudes_fn,
+            )
+        except KeyError as exc:
+            msg = (
+                f"Error instantiating target encoder: {exc}. Please ensure that an "
+                f"encoder is specified for '{self.output_space.name}', even if it is "
+                f"not one of the input spaces: {self.input_spaces}."
+            )
+            raise ValueError(msg) from exc
 
         # We have to explicitly register each encoder as list[Module] will not be
         # automatically picked up by PyTorch

--- a/icenet_mp/models/multistage/decoder_stage.py
+++ b/icenet_mp/models/multistage/decoder_stage.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 import hydra
 import torch
 from omegaconf import DictConfig
+from typing_extensions import override
 
 from icenet_mp.models import BaseModel
 from icenet_mp.types import DataSpace, TensorNTCHW
@@ -29,7 +30,7 @@ class DecoderStage(BaseModel):
         """Initialise a DecoderStage with multiple frozen encoders and a trainable decoder."""
         super().__init__(**kwargs)
 
-        # Copy encoders from EncoderStages, freeze their parameters and register them
+        # Copy encoders from EncoderStages, freeze their parameters and register them.
         self.encoder_names = [encoder.dataset_name for encoder in encoders]
         self.encoders = [copy.deepcopy(encoder.encoder) for encoder in encoders]
         for encoder in self.encoders:
@@ -121,3 +122,12 @@ class DecoderStage(BaseModel):
                 :, 0, self.target_indices, :, :
             ].unsqueeze(1)
         }
+
+    @override
+    def train(self, mode: bool = True) -> "DecoderStage":
+        """Set training mode, but keep the frozen encoders in eval mode."""
+        super().train(mode)
+        if mode:
+            for encoder in self.encoders:
+                encoder.eval()
+        return self

--- a/icenet_mp/models/multistage/encoder_stage.py
+++ b/icenet_mp/models/multistage/encoder_stage.py
@@ -6,7 +6,7 @@ import hydra
 from omegaconf import DictConfig
 
 from icenet_mp.models import BaseModel, EncodeProcessDecode
-from icenet_mp.types import TensorNTCHW
+from icenet_mp.types import DataSpace, TensorNTCHW
 
 if TYPE_CHECKING:
     from icenet_mp.models.decoders import BaseDecoder
@@ -19,7 +19,7 @@ class EncoderStage(BaseModel):
     def __init__(
         self,
         channel_names: list[str],
-        dataset: str,
+        data_space_in: DataSpace,
         encoder: DictConfig,
         decoder: DictConfig,
         latent_space: tuple[int, int],
@@ -31,10 +31,14 @@ class EncoderStage(BaseModel):
         # Store channel names
         self.channel_names = channel_names
 
-        # Encode from a single input space to a latent space
+        # Encode from a single input space to a latent space. For most datasets this
+        # space is one of the model's raw input spaces, found by name. The target
+        # dataset is a special case (a subset of variables from a dataset that may
+        # also be a raw input in its own right, read from the batch's "target" key
+        # rather than a dataset-named key), so its DataSpace is passed in directly.
         self.encoder: BaseEncoder = hydra.utils.instantiate(
             encoder,
-            data_space_in=next(s for s in self.input_spaces if s.name == dataset),
+            data_space_in=data_space_in,
             latent_space=latent_space,
             latitudes_fn=self.latitudes_fn,
             longitudes_fn=self.longitudes_fn,
@@ -57,6 +61,7 @@ class EncoderStage(BaseModel):
         cls,
         *,
         channel_names: list[str],
+        data_space_in: DataSpace,
         dataset: str,
         decoder: DictConfig,
         encoder: DictConfig,
@@ -65,7 +70,7 @@ class EncoderStage(BaseModel):
         """Create an EncoderStage from an existing EncodeProcessDecode template."""
         return cls(
             channel_names=channel_names,
-            dataset=dataset,
+            data_space_in=data_space_in,
             decoder=decoder,
             encoder=encoder,
             hemisphere=template.hemisphere,

--- a/icenet_mp/models/multistage/processor_stage.py
+++ b/icenet_mp/models/multistage/processor_stage.py
@@ -10,9 +10,9 @@ from icenet_mp.models import BaseModel
 from icenet_mp.types import ModelStepOutput, TensorNTCHW
 
 from .decoder_stage import DecoderStage
+from .encoder_stage import EncoderStage
 
 if TYPE_CHECKING:
-    from icenet_mp.models.encoders import BaseEncoder
     from icenet_mp.models.processors import BaseProcessor
 
 logger = logging.getLogger(__name__)
@@ -23,6 +23,7 @@ class ProcessorStage(BaseModel):
         self,
         processor: DictConfig,
         decoder_model: DecoderStage,
+        target_encoder: EncoderStage,
         **kwargs: Any,
     ) -> None:
         """Initialise a ProcessorStage with frozen encoders, a frozen decoder, and a trainable processor."""
@@ -36,18 +37,10 @@ class ProcessorStage(BaseModel):
                 param.requires_grad = False
             self.add_module(encoder.name, encoder)
 
-        # Identify which encoder to use to encode the target if needed
-        try:
-            target_encoder_idx = self.encoder_names.index(decoder_model.target_name)
-        except ValueError:
-            msg = (
-                f"Target dataset '{decoder_model.target_name}' has no corresponding "
-                f"encoder in {self.encoder_names}. ProcessorStage requires an "
-                "appropriate encoder for the target dataset to support latent-space "
-                "losses."
-            )
-            raise ValueError(msg) from None
-        self.target_encoder: BaseEncoder = self.encoders[target_encoder_idx]
+        # Load the target encoder and freeze it
+        self.target_encoder = target_encoder.encoder
+        for param in self.target_encoder.parameters():
+            param.requires_grad = False
 
         # Copy combined latent space from DecoderStage
         combined_latent_space = decoder_model.decoder.data_space_in
@@ -72,20 +65,22 @@ class ProcessorStage(BaseModel):
         *,
         processor: DictConfig,
         decoder_model: DecoderStage,
+        target_encoder: EncoderStage,
     ) -> "ProcessorStage":
         """Create a ProcessorStage from a trained DecoderStage."""
         return cls(
-            processor=processor,
             decoder_model=decoder_model,
             hemisphere=decoder_model.hemisphere,
             input_spaces=[s.to_dict() for s in decoder_model.input_spaces],
+            loss=copy.deepcopy(decoder_model.loss_cfg),
             n_forecast_steps=decoder_model.n_forecast_steps,
             n_history_steps=decoder_model.n_history_steps,
             name=f"processor_{decoder_model.n_history_steps}_to_{decoder_model.n_forecast_steps}",
             optimizer=copy.deepcopy(decoder_model.optimizer_cfg),
             output_space=decoder_model.output_space.to_dict(),
+            processor=processor,
             scheduler=copy.deepcopy(decoder_model.scheduler_cfg),
-            loss=copy.deepcopy(decoder_model.loss_cfg),
+            target_encoder=target_encoder,
         )
 
     def encode_inputs(self, inputs: dict[str, TensorNTCHW]) -> TensorNTCHW:

--- a/icenet_mp/models/multistage/processor_stage.py
+++ b/icenet_mp/models/multistage/processor_stage.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 import hydra
 import torch
 from omegaconf import DictConfig
+from typing_extensions import override
 
 from icenet_mp.models import BaseModel
 from icenet_mp.types import ModelStepOutput, TensorNTCHW
@@ -29,7 +30,7 @@ class ProcessorStage(BaseModel):
         """Initialise a ProcessorStage with frozen encoders, a frozen decoder, and a trainable processor."""
         super().__init__(**kwargs)
 
-        # Copy encoders from DecoderStage, freeze their parameters and register them
+        # Copy encoders from DecoderStage, freeze their parameters and register them.
         self.encoder_names = decoder_model.encoder_names
         self.encoders = [copy.deepcopy(encoder) for encoder in decoder_model.encoders]
         for encoder in self.encoders:
@@ -100,6 +101,17 @@ class ProcessorStage(BaseModel):
         """
         combined_latent: TensorNTCHW = self.encode_inputs(inputs)
         return self.decoder.rollout(self.processor.rollout(combined_latent).prediction)
+
+    @override
+    def train(self, mode: bool = True) -> "ProcessorStage":
+        """Set training mode, but keep frozen modules in eval mode."""
+        super().train(mode)
+        if mode:
+            for encoder in self.encoders:
+                encoder.eval()
+            self.target_encoder.eval()
+            self.decoder.eval()
+        return self
 
     def training_step(
         self,

--- a/icenet_mp/models/processors/base_processor.py
+++ b/icenet_mp/models/processors/base_processor.py
@@ -27,6 +27,13 @@ class BaseProcessor(nn.Module):
         self.data_space_target = data_space_target or data_space
         self.n_forecast_steps = n_forecast_steps
         self.n_history_steps = n_history_steps
+        # We require that the latent spaces for the inputs and target must match
+        if self.data_space_target.shape != self.data_space.shape:
+            msg = (
+                f"Expected data_space_target.shape {self.data_space_target.shape} "
+                f"to match data_space.shape {self.data_space.shape}"
+            )
+            raise ValueError(msg)
 
     def forward(self, x: TensorNCHW) -> TensorNCHW:
         """Forward step: process in NCHW latent space for a single timestep.

--- a/icenet_mp/models/processors/base_processor.py
+++ b/icenet_mp/models/processors/base_processor.py
@@ -27,7 +27,7 @@ class BaseProcessor(nn.Module):
         self.data_space_target = data_space_target or data_space
         self.n_forecast_steps = n_forecast_steps
         self.n_history_steps = n_history_steps
-        # We require that the latent spaces for the inputs and target must match
+        # The latent spatial dimensions (H, W) for the inputs and target must match
         if self.data_space_target.shape != self.data_space.shape:
             msg = (
                 f"Expected data_space_target.shape {self.data_space_target.shape} "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,6 +132,9 @@ def cfg_encoders() -> DictConfig:
             "test-input": {
                 "_target_": "icenet_mp.models.encoders.NaiveLinearEncoder",
             },
+            "target": {
+                "_target_": "icenet_mp.models.encoders.NaiveLinearEncoder",
+            },
         }
     )
 


### PR DESCRIPTION
## Summary
This branch fixes latent target encoding for multistage training, when the prediction target is not available as a standard input encoder path (e.g. when we only want to predict one channel from a multichannel dataset).

## What Changed

- Added a dedicated target encoder in the EPD model.
- Multistage encoder training now also trains that target encoder.
- Decoder stage still uses only input encoders.
- Processor stage now receives the target encoder explicitly for latent target encoding.
- Added a shape check to ensure target latent space matches processor latent space.
- Simplified target variable handling in the data module (defaults to all target variables when not specified).
- Updated test config to include a target encoder entry.
- Adjusted ERA5 dataset area bounds to include corner coverage.

Closes #359 