### PR TITLE
DDPM name fix

### DIFF
--- a/icenet_mp/models/base_model.py
+++ b/icenet_mp/models/base_model.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from copy import deepcopy
 from functools import cached_property
-from typing import Any
+from typing import Any, ClassVar
 
 import hydra
 import torch
@@ -27,6 +27,11 @@ from icenet_mp.types import DataSpace, Hemisphere, ModelStepOutput, TensorNTCHW
 
 class BaseModel(LightningModule, ABC):
     """A base class for all models used in the IceNet-MP project."""
+
+    # Parameters that should be excluded from hyperparameter logging (e.g. local paths)
+    ignored_hparams: ClassVar[frozenset[str]] = frozenset(
+        ("latitudes_fn", "longitudes_fn")
+    )
 
     def __init__(  # noqa: PLR0913
         self,
@@ -89,10 +94,9 @@ class BaseModel(LightningModule, ABC):
         self.train_metrics = MetricCollection(deepcopy(_common_metrics))
         self.validation_metrics = MetricCollection(deepcopy(_common_metrics))
 
-        # Save all non-ignored arguments to __init__ as hyperparameters
-        # This will also save the parameters of whichever child class is used
-        # Note that W&B will log all hyperparameters
-        self.save_hyperparameters(ignore=["latitudes_fn", "longitudes_fn"])
+        # All arguments to the ultimate child class will be logged as hyperparameters,
+        # and saved to W&B, unless explicitly ignored here.
+        self.save_hyperparameters(ignore=[*self.ignored_hparams])
 
     @cached_property
     def latitudes(self) -> dict[str, list[float]]:

--- a/icenet_mp/models/ddpm.py
+++ b/icenet_mp/models/ddpm.py
@@ -1,4 +1,4 @@
-from typing import Any, NoReturn
+from typing import Any, ClassVar, NoReturn
 
 import torch
 import torch.nn.functional as F  # noqa: N812
@@ -51,6 +51,9 @@ class DDPM(BaseModel):
         TensorNTCHW with shape (batch_size, n_forecast_steps * n_output_channels, height, width)
         - Forecasted outputs per timestep and channel, flattened along the channel dimension
     """
+
+    # Parameters that should be excluded from hyperparameter logging (e.g. local paths)
+    ignored_hparams: ClassVar[frozenset[str]] = BaseModel.ignored_hparams | {"mask_dir"}
 
     def __init__(  # noqa: PLR0913
         self,

--- a/icenet_mp/models/ddpm.py
+++ b/icenet_mp/models/ddpm.py
@@ -176,12 +176,8 @@ class DDPM(BaseModel):
             activation=activation,
             dropout_rate=dropout_rate,
         )
-
         self.diffusion = GaussianDiffusion(timesteps=timesteps)
-
         self.learning_rate = learning_rate
-
-        self.save_hyperparameters()
 
     def forward(self, *args: Any, **kwargs: Any) -> NoReturn:
         msg = "This model uses `training_step`, `validation_step`, and `test_step` instead of `forward()`"

--- a/icenet_mp/models/encode_process_decode.py
+++ b/icenet_mp/models/encode_process_decode.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import hydra
 import torch
@@ -15,6 +15,11 @@ if TYPE_CHECKING:
 
 
 class EncodeProcessDecode(BaseModel):
+    """Model that encodes to latent space, processes, then decodes back."""
+
+    # Parameters that should be excluded from hyperparameter logging (e.g. local paths)
+    ignored_hparams: ClassVar[frozenset[str]] = BaseModel.ignored_hparams | {"mask_dir"}
+
     def __init__(
         self,
         *,


### PR DESCRIPTION
Fix for the issue discussed today where DDPM runs do not log their names to W&B

- delete accidental override of BaseModel `save_hyperparameters` call
- allow children of `BaseModel` to specify hyperparameters to ignore

Closes #388.