### PR TITLE
Add AMSE spectral loss for anti-blur (#304)

### DIFF
--- a/docs/src/user-guide/losses.md
+++ b/docs/src/user-guide/losses.md
@@ -1,0 +1,53 @@
+# Loss functions
+
+## Selecting a loss
+
+The training loss is a Hydra config group. The default is set in
+`icenet_mp/config/base.yaml` (`loss: huber`) and can be overridden on any command
+line:
+
+```bash
+imp train --config-name <config> loss=mse
+imp train --config-name <config> loss=amse loss.mode=hybrid loss.spectral_weight=0.1
+```
+
+Each option corresponds to a file in `icenet_mp/config/loss/`, whose header comments
+carry the full parameter documentation; this page summarises how to choose between
+them.
+
+## Supported losses
+
+| `loss=` | what it is | pros | cons |
+|---|---|---|---|
+| `huber` (default) | quadratic below `delta`, linear above | smooth near zero, robust to outliers, loss stays in target units above `delta` | needs `delta` chosen; below `delta` it inherits MSE's blur incentive (see AMSE) |
+| `mse` | squared residual | smooth everywhere; strong gradient on large errors | outlier-sensitive; strongest amplitude-damping (blur) incentive |
+| `mae` | absolute residual | fully outlier-robust; constant gradient | non-smooth at zero; weak signal on small errors |
+| `rmse` | `sqrt(MSE + eps)` | interpretable in target units | same optimum as MSE; gradient rescaled by the running loss value |
+| `smooth_l1` | Huber variant with `beta` transition | as Huber; PyTorch-native parameterisation | as Huber |
+| `weighted_mse` / `weighted_l1` / `weighted_bce` | elementwise `sample_weights` × MSE / L1 / BCE-with-logits | spatial weighting (e.g. emphasise the ice edge or active cells) | weights must be supplied and justified; BCE assumes a [0, 1] classification framing |
+| `amse` | spectral anti-blur loss (Subich et al. 2025, arXiv:2501.19374, flat-grid adaptation) | removes the "double penalty": matching the target's power spectrum per scale band is optimal at any coherence, so partially-predictable fine scales are no longer rewarded for being damped | more expensive than pointwise losses (FFT per step); `hybrid` mode introduces `spectral_weight` to calibrate |
+
+## Why an anti-blur loss exists (the double penalty, in two sentences)
+
+For any squared-error-type loss, the loss-optimal amplitude of a spatial scale the
+model cannot predict perfectly equals its coherence with the target — at 50 %
+coherence the optimal move is to halve that scale's amplitude. Spatial blur is
+therefore the *optimum* of pointwise training, not a failure of it; AMSE modifies the
+per-scale decomposition so that preserving the target's spectrum is optimal instead
+(full derivation in the header of `icenet_mp/losses/amse_loss.py`).
+
+### AMSE options
+
+* `loss.mode=hybrid` (default): standard Huber plus `spectral_weight` × the AMSE
+  excess. At `spectral_weight=0` this is exactly the Huber control. Calibrate
+  `spectral_weight` so the spectral term carries ~10 % of the total loss at
+  initialisation (the untrained model's Huber/excess ratio differs per architecture).
+* `loss.mode=pure`: the AMSE objective alone (no `spectral_weight`).
+* `loss.wavenumber_weight=fastnet` (default off): re-weights the spectral penalty
+  toward fine scales by `max(N_k * k^sqrt(3), 1)` (FastNet, arXiv:2509.17601) at
+  unchanged total, moving the penalty onto ice-edge scales.
+* `loss.static_ref_path=<path.npy>` (default off): subtracts a static reference field
+  from both prediction and target before the spectral terms, so static
+  climatological structure does not dilute the anti-blur signal.
+
+Both optional flags are bit-for-bit inert when off.

--- a/icenet_mp/config/loss/amse.yaml
+++ b/icenet_mp/config/loss/amse.yaml
@@ -35,3 +35,14 @@ spectral_weight: 0.1 # Weight of the spectral excess term in hybrid mode
 delta: 0.5 # Huber transition point for the hybrid base term (matches loss/huber.yaml)
 merge_bins_below: 4 # Annuli with rounded |k| <= this value share one bin
 eps: 1.0e-12 # Guard inside sqrt(P*T); keeps gradients finite for zero fields
+
+# Per-bin wavenumber upweighting of the spectral terms.
+#   null / "none" : unweighted annular sum (Subich reference) - DEFAULT, and
+#                   bit-for-bit identical to the loss before this option existed
+#   "fastnet"     : gamma_k = max(N_k * k^sqrt(3), 1) (FastNet, arXiv:2509.17601),
+#                   N_k = number of 2D-DFT modes in bin k. Rescaled by a detached
+#                   scalar so the batch total penalty is unchanged, i.e. the
+#                   penalty is REDISTRIBUTED towards fine scales at fixed
+#                   magnitude, keeping spectral_weight and the lr comparable
+#                   with the unweighted arm.
+wavenumber_weight: null

--- a/icenet_mp/config/loss/amse.yaml
+++ b/icenet_mp/config/loss/amse.yaml
@@ -1,0 +1,37 @@
+# =============================================================================
+# AMSE (Adjusted MSE) spectral anti-blur loss
+# =============================================================================
+# Reference: Subich et al. (2025), "Fixing the Double Penalty in Data-Driven
+#            Weather Forecasting Through a Modified Spherical Harmonic Loss
+#            Function", arXiv:2501.19374. Flat-grid (2D-DFT) adaptation;
+#            independent reimplementation of the published formula.
+#
+# Why: pointwise squared-error losses pay a "double penalty" for displaced
+# features (once missing, once spurious), so the loss-optimal forecast damps
+# the amplitude of partially-predictable scales — i.e. it blurs. Per scale
+# group, the MSE-optimal amplitude ratio equals the coherence with the target.
+# AMSE re-weights the decorrelation term so that shrinking the predicted
+# amplitude no longer reduces it; the optimum then preserves the target's
+# power spectrum scale by scale.
+#
+# Scale groups: annular bins of isotropic wavenumber |k| of the 2D DFT.
+# On the 432-cell, 25 km EASE2 grid, bin k corresponds to wavelength
+# 10800/k km. The domain boundary ring is inactive (exactly 0 in both
+# prediction and target), so the DFT periodicity assumption introduces no
+# boundary discontinuity.
+#
+# Modes:
+#   hybrid : Huber(delta) + spectral_weight * (AMSE - MSE) excess term.
+#            Reduces to the standard Huber control at spectral_weight = 0.
+#   pure   : the AMSE formula alone (paper Eq. 6, parameter-free).
+#
+# Scope: intended for spatial-field predictions (encode-process-decode
+# models). Untested with losses computed in other spaces (e.g. DDPM v-space).
+# =============================================================================
+
+_target_: icenet_mp.losses.amse_loss.AMSELoss
+mode: hybrid # "hybrid" (Huber + weighted spectral excess) or "pure" (AMSE alone)
+spectral_weight: 0.1 # Weight of the spectral excess term in hybrid mode
+delta: 0.5 # Huber transition point for the hybrid base term (matches loss/huber.yaml)
+merge_bins_below: 4 # Annuli with rounded |k| <= this value share one bin
+eps: 1.0e-12 # Guard inside sqrt(P*T); keeps gradients finite for zero fields

--- a/icenet_mp/losses/__init__.py
+++ b/icenet_mp/losses/__init__.py
@@ -1,8 +1,10 @@
+from .amse_loss import AMSELoss
 from .weighted_bce_loss import WeightedBCEWithLogitsLoss
 from .weighted_l1_loss import WeightedL1Loss
 from .weighted_mse_loss import WeightedMSELoss
 
 __all__ = [
+    "AMSELoss",
     "WeightedBCEWithLogitsLoss",
     "WeightedL1Loss",
     "WeightedMSELoss",

--- a/icenet_mp/losses/amse_loss.py
+++ b/icenet_mp/losses/amse_loss.py
@@ -1,0 +1,224 @@
+"""Adjusted-MSE (AMSE) spectral anti-blur loss on a flat grid.
+
+Adaptation of the spherical-harmonic AMSE loss of Subich et al. (2025),
+"Fixing the Double Penalty in Data-Driven Weather Forecasting Through a
+Modified Spherical Harmonic Loss Function" (arXiv:2501.19374), to the flat
+equal-area EASE2 grids used by icenet-mp. Independent reimplementation of the
+published formula; reference implementation (spherical, JAX) at
+https://github.com/csubich/graphcast (branch ``amse``).
+
+Pointwise squared-error losses reward damping the amplitude of scales the
+model cannot predict exactly (the "double penalty"): per scale group, the
+MSE-optimal amplitude ratio equals the coherence with the target, so partially
+predictable fine scales are systematically blurred. AMSE removes this
+incentive. Writing per scale group k the powers P_k(x), P_k(y) and coherence
+Coh_k(x, y) of prediction x and target y,
+
+    MSE(x, y)  = sum_k [ (sqrt(P_k(x)) - sqrt(P_k(y)))^2
+                         + 2 * sqrt(P_k(x) * P_k(y)) * (1 - Coh_k(x, y)) ]
+    AMSE(x, y) = sum_k [ (sqrt(P_k(x)) - sqrt(P_k(y)))^2
+                         + 2 * max(P_k(x), P_k(y)) * (1 - Coh_k(x, y)) ]
+
+so under AMSE the decorrelation penalty can no longer be reduced by shrinking
+the predicted amplitude, and the amplitude optimum at any fixed coherence is
+P_k(x) = P_k(y): the target's power spectrum is preserved scale by scale.
+
+On the flat grid the orthonormal decomposition is the 2D DFT and the scale
+groups are annular bins of the isotropic wavenumber |k| = sqrt(kx^2 + ky^2);
+Parseval's identity makes the group decomposition of MSE exact, which is the
+only property the construction needs (Subich et al., Sec. 2.2 and 4.2).
+
+Scope: designed and tested for spatial-field predictions (single-stage
+encode-process-decode). Using this loss with models whose training loss lives
+in a different space (e.g. DDPM v-space) is untested.
+"""
+
+import torch
+from torch import nn
+from torch.nn import functional
+
+# Type alias for the cached per-(H, W, device) binning tensors:
+# (flat mode->bin index, flat mode weights, indices of non-empty bins)
+BinCache = tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+
+# Fields must carry at least (batch-like, H, W) dimensions.
+MIN_FIELD_NDIM = 3
+
+
+class AMSELoss(nn.Module):
+    """Adjusted-MSE (anti-double-penalty) spectral loss on a flat grid.
+
+    Two modes:
+
+    - ``"hybrid"`` (default): the repo's standard Huber loss plus
+      ``spectral_weight`` times the AMSE *excess*
+      ``sum_k 2 * (max(P_k(x), P_k(y)) - sqrt(P_k(x) * P_k(y))) * (1 - Coh_k)``,
+      which is >= 0, zero iff per-bin spectra match or coherence is perfect,
+      and reduces to the unmodified Huber control at ``spectral_weight=0``.
+    - ``"pure"``: the AMSE formula itself (per-bin amplitude + decorrelation
+      terms plus a direct DC term), averaged over fields.
+
+    Numerical guards follow the reference implementation: ``eps`` inside the
+    geometric-mean square root (the coherence denominator is singular for a
+    zero field), coherence clamped at 1 from above (Cauchy-Schwarz can be
+    violated by the eps), the mean/DC component handled as a direct squared
+    difference (catastrophic cancellation), and all spectral arithmetic in
+    float32.
+    """
+
+    def __init__(
+        self,
+        mode: str = "hybrid",
+        spectral_weight: float = 0.1,
+        delta: float = 0.5,
+        merge_bins_below: int = 4,
+        eps: float = 1e-12,
+    ) -> None:
+        """Initialise the AMSE loss.
+
+        Args:
+            mode: "hybrid" (Huber + spectral_weight * AMSE excess) or "pure"
+                (the AMSE formula alone).
+            spectral_weight: weight of the spectral excess term in hybrid mode.
+            delta: Huber transition point for the hybrid base term (matches
+                the repo's default Huber loss).
+            merge_bins_below: annuli with rounded |k| <= this value share one
+                bin (the lowest annuli contain too few modes for a stable
+                per-sample coherence estimate).
+            eps: additive guard inside sqrt(P_k(x) * P_k(y)); keeps gradients
+                finite when either field has an empty scale bin.
+
+        """
+        super().__init__()
+        if mode not in ("hybrid", "pure"):
+            msg = f"Unknown AMSELoss mode: {mode!r} (expected 'hybrid' or 'pure')"
+            raise ValueError(msg)
+        if merge_bins_below < 1:
+            msg = f"merge_bins_below must be >= 1, got {merge_bins_below}"
+            raise ValueError(msg)
+        self.mode = mode
+        self.spectral_weight = spectral_weight
+        self.delta = delta
+        self.merge_bins_below = merge_bins_below
+        self.eps = eps
+        # Lazily-built cache of binning tensors, keyed by (H, W, device).
+        # A plain dict (not buffers) so it never enters the state dict.
+        self._bin_cache: dict[tuple[int, int, str], BinCache] = {}
+
+    def _binning(self, height: int, width: int, device: torch.device) -> BinCache:
+        """Return (bin index, mode weight, non-empty bin ids) for an H x W grid."""
+        key = (height, width, str(device))
+        cached = self._bin_cache.get(key)
+        if cached is not None:
+            return cached
+        ky = torch.fft.fftfreq(height, device=device) * height
+        kx = torch.fft.rfftfreq(width, device=device) * width
+        kmag = torch.sqrt(ky[:, None] ** 2 + kx[None, :] ** 2)
+        bins = torch.round(kmag).long()
+        # Merge the sparse low-|k| annuli (excluding DC) into one bin.
+        bins = torch.where(
+            (bins >= 1) & (bins < self.merge_bins_below), self.merge_bins_below, bins
+        )
+        # rfft halves the x axis: interior columns stand for +-kx pairs and
+        # count twice; column 0 and (for even W) the Nyquist column appear once.
+        weights = torch.full(kmag.shape, 2.0, device=device)
+        weights[:, 0] = 1.0
+        if width % 2 == 0:
+            weights[:, -1] = 1.0
+        # The DC mode is excluded from the annuli (handled as a direct term).
+        weights[0, 0] = 0.0
+        bins_flat = bins.reshape(-1)
+        weights_flat = weights.reshape(-1)
+        counts = torch.zeros(int(bins_flat.max()) + 1, device=device)
+        counts.scatter_add_(0, bins_flat, (weights_flat > 0).float())
+        present = torch.nonzero(counts > 0, as_tuple=False).squeeze(1)
+        result = (bins_flat, weights_flat, present)
+        self._bin_cache[key] = result
+        return result
+
+    def binned_spectra(
+        self, prediction: torch.Tensor, target: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Per-field, per-bin spectral statistics of the mean-removed fields.
+
+        Returns:
+            Tuple ``(P, T, C, dc)`` where ``P[i, b]`` / ``T[i, b]`` are the
+            prediction/target powers of field ``i`` in |k|-bin ``b``,
+            ``C[i, b]`` is the real cross-spectrum, and ``dc[i]`` is the
+            squared difference of the field means. Powers are normalised so
+            that ``sum_b (P + T - 2C) + dc`` equals the per-field MSE
+            (Parseval's identity).
+
+        """
+        if prediction.shape != target.shape:
+            msg = (
+                f"prediction shape {tuple(prediction.shape)} "
+                f"!= target shape {tuple(target.shape)}"
+            )
+            raise ValueError(msg)
+        if prediction.ndim < MIN_FIELD_NDIM:
+            msg = (
+                f"expected at least {MIN_FIELD_NDIM} dimensions, got {prediction.ndim}"
+            )
+            raise ValueError(msg)
+        height, width = prediction.shape[-2], prediction.shape[-1]
+        fields_p = prediction.reshape(-1, height, width).float()
+        fields_t = target.reshape(-1, height, width).float()
+        mean_p = fields_p.mean(dim=(-2, -1))
+        mean_t = fields_t.mean(dim=(-2, -1))
+        dc = (mean_p - mean_t) ** 2
+        spec_p = torch.fft.rfft2(fields_p - mean_p[:, None, None], norm="ortho")
+        spec_t = torch.fft.rfft2(fields_t - mean_t[:, None, None], norm="ortho")
+        bins_flat, weights_flat, present = self._binning(height, width, fields_p.device)
+        n_fields = spec_p.shape[0]
+        n_bins_total = int(bins_flat.max()) + 1
+        scale = 1.0 / (height * width)
+        index = bins_flat.unsqueeze(0).expand(n_fields, -1)
+
+        def accumulate(values: torch.Tensor) -> torch.Tensor:
+            out = torch.zeros(n_fields, n_bins_total, device=values.device)
+            out.scatter_add_(
+                1, index, (values * weights_flat).reshape(n_fields, -1) * scale
+            )
+            return out.index_select(1, present)
+
+        power_p = accumulate(spec_p.abs().reshape(n_fields, -1) ** 2)
+        power_t = accumulate(spec_t.abs().reshape(n_fields, -1) ** 2)
+        cross = accumulate((spec_p * spec_t.conj()).real.reshape(n_fields, -1))
+        return power_p, power_t, cross, dc
+
+    def spectral_excess(
+        self, prediction: torch.Tensor, target: torch.Tensor
+    ) -> torch.Tensor:
+        """Per-field AMSE excess ``AMSE - MSE`` (the pure anti-blur surcharge).
+
+        Non-negative; zero iff, in every |k|-bin, the two power spectra match
+        or the coherence is perfect. Shrinking predicted amplitude below the
+        target's cannot reduce this term.
+        """
+        power_p, power_t, cross, _ = self.binned_spectra(prediction, target)
+        geo_mean = torch.sqrt(self.eps + power_p * power_t)
+        coherence = torch.clamp(cross / geo_mean, max=1.0)
+        excess_weight = (torch.maximum(power_p, power_t) - geo_mean).clamp_min(0.0)
+        return (2.0 * excess_weight * (1.0 - coherence)).sum(dim=1)
+
+    def pure_amse(self, prediction: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        """Per-field AMSE (amplitude + adjusted decorrelation terms + DC term)."""
+        power_p, power_t, cross, dc = self.binned_spectra(prediction, target)
+        geo_mean = torch.sqrt(self.eps + power_p * power_t)
+        coherence = torch.clamp(cross / geo_mean, max=1.0)
+        amplitude = (power_p + power_t - 2.0 * geo_mean).clamp_min(0.0)
+        decorrelation = 2.0 * torch.maximum(power_p, power_t) * (1.0 - coherence)
+        return (amplitude + decorrelation).sum(dim=1) + dc
+
+    def forward(self, prediction: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        """Return the scalar loss for prediction/target of shape [..., H, W]."""
+        if self.mode == "pure":
+            return self.pure_amse(prediction, target).mean()
+        base = functional.huber_loss(
+            prediction.float(), target.float(), delta=self.delta
+        )
+        return (
+            base
+            + self.spectral_weight * self.spectral_excess(prediction, target).mean()
+        )

--- a/icenet_mp/losses/amse_loss.py
+++ b/icenet_mp/losses/amse_loss.py
@@ -68,7 +68,7 @@ class AMSELoss(nn.Module):
 
     def __init__(
         self,
-        mode: str = "hybrid",
+        mode: Literal["hybrid", "pure"] = "hybrid",
         spectral_weight: float = 0.1,
         delta: float = 0.5,
         merge_bins_below: int = 4,

--- a/icenet_mp/losses/amse_loss.py
+++ b/icenet_mp/losses/amse_loss.py
@@ -33,10 +33,13 @@ encode-process-decode). Using this loss with models whose training loss lives
 in a different space (e.g. DDPM v-space) is untested.
 """
 
+from typing import Literal
+
 import torch
 from torch import nn
 from torch.nn import functional
-from typing import Literal
+
+AMSEMode = Literal["hybrid", "pure"]
 
 # Type alias for the cached per-(H, W, device) binning tensors:
 # (flat mode->bin index, flat mode weights, indices of non-empty bins)
@@ -69,7 +72,7 @@ class AMSELoss(nn.Module):
 
     def __init__(
         self,
-        mode: Literal["hybrid", "pure"] = "hybrid",
+        mode: AMSEMode = "hybrid",
         spectral_weight: float = 0.1,
         delta: float = 0.5,
         merge_bins_below: int = 4,

--- a/icenet_mp/losses/amse_loss.py
+++ b/icenet_mp/losses/amse_loss.py
@@ -93,6 +93,7 @@ class AMSELoss(nn.Module):
 
     def __init__(  # noqa: PLR0913 - flat config-driven knobs, all defaulted
         self,
+        *,
         mode: AMSEMode = "hybrid",
         spectral_weight: float = 0.1,
         delta: float = 0.5,

--- a/icenet_mp/losses/amse_loss.py
+++ b/icenet_mp/losses/amse_loss.py
@@ -33,20 +33,33 @@ encode-process-decode). Using this loss with models whose training loss lives
 in a different space (e.g. DDPM v-space) is untested.
 """
 
+import logging
+import math
 from typing import Literal
 
+import numpy as np
 import torch
 from torch import nn
 from torch.nn import functional
 
+logger = logging.getLogger(__name__)
+
 AMSEMode = Literal["hybrid", "pure"]
 
 # Type alias for the cached per-(H, W, device) binning tensors:
-# (flat mode->bin index, flat mode weights, indices of non-empty bins)
-BinCache = tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+# (flat mode->bin index, flat mode weights, indices of non-empty bins,
+#  per-bin wavenumber weight gamma_k aligned with those indices)
+BinCache = tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
 
 # Fields must carry at least (batch-like, H, W) dimensions.
 MIN_FIELD_NDIM = 3
+
+# Accepted values of ``wavenumber_weight`` (None is normalised to "none").
+WAVENUMBER_WEIGHTS = ("none", "fastnet")
+
+# FastNet (arXiv:2509.17601) upweights annular bin k by
+# gamma_k = max(N_k * k**sqrt(3), 1), N_k = number of spectral modes in bin k.
+FASTNET_EXPONENT = math.sqrt(3.0)
 
 
 class AMSELoss(nn.Module):
@@ -62,6 +75,14 @@ class AMSELoss(nn.Module):
     - ``"pure"``: the AMSE formula itself (per-bin amplitude + decorrelation
       terms plus a direct DC term), averaged over fields.
 
+    Both modes sum the annular bins UNWEIGHTED by default, as in the Subich
+    reference. ``wavenumber_weight="fastnet"`` instead upweights each bin by
+    ``gamma_k = max(N_k * k**sqrt(3), 1)`` (FastNet, arXiv:2509.17601), which
+    moves the penalty from the large scales that dominate a steep sea-ice
+    spectrum onto the fine scales where the ice edge lives; the total is held
+    fixed so ``spectral_weight`` stays comparable across the two settings (see
+    ``_weight_bins``). Default OFF: unset, the loss is bit-for-bit unchanged.
+
     Numerical guards follow the reference implementation: ``eps`` inside the
     geometric-mean square root (the coherence denominator is singular for a
     zero field), coherence clamped at 1 from above (Cauchy-Schwarz can be
@@ -70,13 +91,15 @@ class AMSELoss(nn.Module):
     float32.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913 - flat config-driven knobs, all defaulted
         self,
         mode: AMSEMode = "hybrid",
         spectral_weight: float = 0.1,
         delta: float = 0.5,
         merge_bins_below: int = 4,
         eps: float = 1e-12,
+        static_ref_path: str | None = None,
+        wavenumber_weight: str | None = None,
     ) -> None:
         """Initialise the AMSE loss.
 
@@ -91,6 +114,12 @@ class AMSELoss(nn.Module):
                 per-sample coherence estimate).
             eps: additive guard inside sqrt(P_k(x) * P_k(y)); keeps gradients
                 finite when either field has an empty scale bin.
+            static_ref_path: optional .npy path of a static reference field
+                subtracted from both fields before the spectral terms.
+            wavenumber_weight: per-bin upweighting of the spectral terms.
+                None / "none" (default) leaves every annulus at weight 1, i.e.
+                the unweighted Subich sum; "fastnet" applies
+                gamma_k = max(N_k * k**sqrt(3), 1) (see ``_weight_bins``).
 
         """
         super().__init__()
@@ -100,17 +129,33 @@ class AMSELoss(nn.Module):
         if merge_bins_below < 1:
             msg = f"merge_bins_below must be >= 1, got {merge_bins_below}"
             raise ValueError(msg)
+        weight_mode = (wavenumber_weight or "none").lower()
+        if weight_mode not in WAVENUMBER_WEIGHTS:
+            msg = (
+                f"Unknown AMSELoss wavenumber_weight: {wavenumber_weight!r} "
+                f"(expected None or one of {WAVENUMBER_WEIGHTS})"
+            )
+            raise ValueError(msg)
         self.mode = mode
         self.spectral_weight = spectral_weight
         self.delta = delta
         self.merge_bins_below = merge_bins_below
         self.eps = eps
+        self.wavenumber_weight = weight_mode
+        # Optional anomaly transform: a static reference field (e.g. the
+        # training-period mean SIC) subtracted from BOTH prediction and target
+        # before the spectral terms. Removes the shared static structure
+        # (coastline/climatological ring) that otherwise dominates band power
+        # and inflates coherence, diluting the anti-blur excess (measured
+        # 2026-07-27: static share 63-86% of band power on full_south).
+        self.static_ref_path = static_ref_path
+        self._static_ref: torch.Tensor | None = None
         # Lazily-built cache of binning tensors, keyed by (H, W, device).
         # A plain dict (not buffers) so it never enters the state dict.
         self._bin_cache: dict[tuple[int, int, str], BinCache] = {}
 
     def _binning(self, height: int, width: int, device: torch.device) -> BinCache:
-        """Return (bin index, mode weight, non-empty bin ids) for an H x W grid."""
+        """Return (bin index, mode weight, non-empty bin ids, gamma_k) for H x W."""
         key = (height, width, str(device))
         cached = self._bin_cache.get(key)
         if cached is not None:
@@ -136,9 +181,83 @@ class AMSELoss(nn.Module):
         counts = torch.zeros(int(bins_flat.max()) + 1, device=device)
         counts.scatter_add_(0, bins_flat, (weights_flat > 0).float())
         present = torch.nonzero(counts > 0, as_tuple=False).squeeze(1)
-        result = (bins_flat, weights_flat, present)
+        # FastNet wavenumber weight gamma_k = max(N_k * k**sqrt(3), 1), cached
+        # alongside the bin tensors and used only when wavenumber_weight is on.
+        # N_k is the number of modes of the FULL 2D DFT falling in bin k, so it
+        # is the sum of the SAME rfft double-count weights used for the powers
+        # (no second binning): interior columns count 2, column 0 and the even-W
+        # Nyquist column count 1, and DC carries weight 0. k is the bin's
+        # representative isotropic wavenumber, i.e. the bin index, which for the
+        # merged low bin is merge_bins_below.
+        mode_counts = torch.zeros_like(counts)
+        mode_counts.scatter_add_(0, bins_flat, weights_flat)
+        wavenumber = torch.arange(counts.numel(), device=device, dtype=counts.dtype)
+        gamma = torch.clamp(mode_counts * wavenumber**FASTNET_EXPONENT, min=1.0)
+        gamma = gamma.index_select(0, present)
+        if self.wavenumber_weight != "none":
+            # Once per grid, and only when the option is on: a run-log
+            # fingerprint proving the flag actually reached the loss.
+            logger.info(
+                "AMSE wavenumber weighting %r engaged on %dx%d: %d active bins, "
+                "gamma in [%.4g, %.4g]",
+                self.wavenumber_weight,
+                height,
+                width,
+                int(present.numel()),
+                float(gamma.min()),
+                float(gamma.max()),
+            )
+        result = (bins_flat, weights_flat, present, gamma)
         self._bin_cache[key] = result
         return result
+
+    def _weight_bins(
+        self, contributions: torch.Tensor, height: int, width: int
+    ) -> torch.Tensor:
+        """Apply the FastNet per-bin upweighting to [n_fields, n_bins] terms.
+
+        With ``wavenumber_weight="none"`` the input is returned untouched, so
+        the default path is bit-for-bit the unweighted Subich sum.
+
+        With ``"fastnet"`` each bin is multiplied by
+        ``gamma_k = max(N_k * k**sqrt(3), 1)`` and the result is divided by a
+        DETACHED scalar chosen so the batch total is unchanged:
+
+            sum_(i,k) gamma_k * c_ik / Z == sum_(i,k) c_ik,
+            Z = sum_(i,k) gamma_k * c_ik / sum_(i,k) c_ik.
+
+        Rationale: raw gamma_k grows like k**2.7 (N_k ~ 2*pi*k), spanning ~7
+        orders of magnitude across the bins of a 432x432 grid, so the raw
+        weighted sum would change the SCALE of the spectral term by orders of
+        magnitude. That silently rescales the effective learning rate of the
+        spectral branch and makes ``spectral_weight`` mean something different
+        from its value in the unweighted arm - which would confound the
+        factorial comparison the flag exists to serve. Normalising gamma to
+        mean 1 over the active bins does NOT fix this: gamma is strongly
+        anti-correlated with where the penalty sits (the penalty is concentrated
+        at low |k| where gamma is smallest), so the total would still move by a
+        large factor. Preserving the total makes the change purely a
+        REDISTRIBUTION of the penalty across scales - exactly the intended
+        intervention - and keeps the arm trainable at the unweighted arm's lr.
+        Z is detached, so gradients are those of a fixed per-bin reweighting
+        (a constant rescale of an ordinary weighted sum), not of a ratio.
+
+        The DC term is deliberately NOT weighted. It is not an annulus (the DC
+        mode carries binning weight 0 and never reaches a bin), and the FastNet
+        formula itself assigns it gamma_0 = max(0 * 0**sqrt(3), 1) = 1; it is
+        the domain-mean bias, which must keep full weight.
+        """
+        if self.wavenumber_weight == "none":
+            return contributions
+        gamma = self._binning(height, width, contributions.device)[3]
+        weighted = contributions * gamma
+        # Both sums are non-negative (every per-bin term is clamped at 0), so
+        # the ratio is a weighted mean of gamma >= 1: bounded and well posed.
+        # The eps pair makes Z = 1 for the exact-match case (0 / 0).
+        scale = (weighted.detach().sum() + self.eps) / (
+            contributions.detach().sum() + self.eps
+        )
+        return weighted / scale
 
     def binned_spectra(
         self, prediction: torch.Tensor, target: torch.Tensor
@@ -168,12 +287,37 @@ class AMSELoss(nn.Module):
         height, width = prediction.shape[-2], prediction.shape[-1]
         fields_p = prediction.reshape(-1, height, width).float()
         fields_t = target.reshape(-1, height, width).float()
+        if self.static_ref_path is not None:
+            if self._static_ref is None:
+                ref = torch.from_numpy(np.load(self.static_ref_path)).float()
+                if not torch.isfinite(ref).all():
+                    # A silently all-NaN reference field reached a production GPU job
+                    # on 2026-07-27 and NaN'd every loss while the model itself was
+                    # healthy. Fail loudly at load time instead.
+                    n_bad = int((~torch.isfinite(ref)).sum())
+                    msg = (
+                        f"static_ref at {self.static_ref_path} has {n_bad} non-finite "
+                        f"cells of {ref.numel()}; refusing to train on it."
+                    )
+                    raise ValueError(msg)
+                if ref.shape != (height, width):
+                    msg = (
+                        f"static_ref shape {tuple(ref.shape)} does not match "
+                        f"field shape ({height}, {width})"
+                    )
+                    raise ValueError(msg)
+                self._static_ref = ref
+            ref = self._static_ref.to(device=fields_p.device, dtype=fields_p.dtype)
+            fields_p = fields_p - ref
+            fields_t = fields_t - ref
         mean_p = fields_p.mean(dim=(-2, -1))
         mean_t = fields_t.mean(dim=(-2, -1))
         dc = (mean_p - mean_t) ** 2
         spec_p = torch.fft.rfft2(fields_p - mean_p[:, None, None], norm="ortho")
         spec_t = torch.fft.rfft2(fields_t - mean_t[:, None, None], norm="ortho")
-        bins_flat, weights_flat, present = self._binning(height, width, fields_p.device)
+        bins_flat, weights_flat, present, _ = self._binning(
+            height, width, fields_p.device
+        )
         n_fields = spec_p.shape[0]
         n_bins_total = int(bins_flat.max()) + 1
         scale = 1.0 / (height * width)
@@ -204,7 +348,9 @@ class AMSELoss(nn.Module):
         geo_mean = torch.sqrt(self.eps + power_p * power_t)
         coherence = torch.clamp(cross / geo_mean, max=1.0)
         excess_weight = (torch.maximum(power_p, power_t) - geo_mean).clamp_min(0.0)
-        return (2.0 * excess_weight * (1.0 - coherence)).sum(dim=1)
+        contributions = 2.0 * excess_weight * (1.0 - coherence)
+        height, width = prediction.shape[-2], prediction.shape[-1]
+        return self._weight_bins(contributions, height, width).sum(dim=1)
 
     def pure_amse(self, prediction: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
         """Per-field AMSE (amplitude + adjusted decorrelation terms + DC term)."""
@@ -213,7 +359,9 @@ class AMSELoss(nn.Module):
         coherence = torch.clamp(cross / geo_mean, max=1.0)
         amplitude = (power_p + power_t - 2.0 * geo_mean).clamp_min(0.0)
         decorrelation = 2.0 * torch.maximum(power_p, power_t) * (1.0 - coherence)
-        return (amplitude + decorrelation).sum(dim=1) + dc
+        height, width = prediction.shape[-2], prediction.shape[-1]
+        contributions = self._weight_bins(amplitude + decorrelation, height, width)
+        return contributions.sum(dim=1) + dc
 
     def forward(self, prediction: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
         """Return the scalar loss for prediction/target of shape [..., H, W]."""

--- a/icenet_mp/losses/amse_loss.py
+++ b/icenet_mp/losses/amse_loss.py
@@ -36,6 +36,7 @@ in a different space (e.g. DDPM v-space) is untested.
 import torch
 from torch import nn
 from torch.nn import functional
+from typing import Literal
 
 # Type alias for the cached per-(H, W, device) binning tensors:
 # (flat mode->bin index, flat mode weights, indices of non-empty bins)

--- a/tests/models/test_amse_loss.py
+++ b/tests/models/test_amse_loss.py
@@ -4,7 +4,7 @@ import torch
 from omegaconf import OmegaConf
 from torch.nn import functional
 
-from icenet_mp.losses.amse_loss import AMSELoss
+from icenet_mp.losses.amse_loss import AMSELoss, AMSEMode
 
 
 def make_fields(
@@ -40,12 +40,12 @@ class TestAMSELoss:
 
     def test_unknown_mode_raises(self) -> None:
         with pytest.raises(ValueError, match="mode"):
-            AMSELoss(mode="not-a-mode")
+            AMSELoss(mode="not-a-mode")  # type: ignore[arg-type]
         with pytest.raises(ValueError, match="merge_bins_below"):
             AMSELoss(merge_bins_below=0)
 
     @pytest.mark.parametrize("mode", ["hybrid", "pure"])
-    def test_identity_is_zero(self, mode: str) -> None:
+    def test_identity_is_zero(self, mode: AMSEMode) -> None:
         prediction, _ = make_fields()
         loss_fn = AMSELoss(mode=mode)
         assert loss_fn(prediction, prediction).item() == pytest.approx(0.0, abs=1e-6)
@@ -96,7 +96,7 @@ class TestAMSELoss:
         assert gradient.item() < 0.0
 
     @pytest.mark.parametrize("mode", ["hybrid", "pure"])
-    def test_zero_field_gradients_finite(self, mode: str) -> None:
+    def test_zero_field_gradients_finite(self, mode: AMSEMode) -> None:
         _, target = make_fields(seed=5)
         prediction = torch.zeros_like(target, requires_grad=True)
         loss = AMSELoss(mode=mode)(prediction, target)
@@ -105,7 +105,7 @@ class TestAMSELoss:
         assert torch.isfinite(prediction.grad).all()
 
     @pytest.mark.parametrize("mode", ["hybrid", "pure"])
-    def test_masked_fields(self, mode: str) -> None:
+    def test_masked_fields(self, mode: AMSEMode) -> None:
         """Fields zeroed outside an active region give finite loss and gradients."""
         prediction, target = make_fields(seed=6)
         mask = torch.zeros(32, 32)

--- a/tests/models/test_amse_loss.py
+++ b/tests/models/test_amse_loss.py
@@ -1,4 +1,7 @@
+import math
+
 import hydra
+import numpy as np
 import pytest
 import torch
 from omegaconf import OmegaConf
@@ -134,3 +137,247 @@ class TestAMSELoss:
         loss = AMSELoss()(prediction.to(torch.bfloat16), target.to(torch.bfloat16))
         assert loss.dtype == torch.float32
         assert torch.isfinite(loss)
+
+
+def penalty_by_bin(
+    loss_fn: AMSELoss, prediction: torch.Tensor, target: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return (bin wavenumbers, batch-summed anti-blur contribution per bin)."""
+    power_p, power_t, cross, _ = loss_fn.binned_spectra(prediction, target)
+    geo_mean = torch.sqrt(loss_fn.eps + power_p * power_t)
+    coherence = torch.clamp(cross / geo_mean, max=1.0)
+    excess = (torch.maximum(power_p, power_t) - geo_mean).clamp_min(0.0)
+    contributions = 2.0 * excess * (1.0 - coherence)
+    height, width = prediction.shape[-2], prediction.shape[-1]
+    weighted = loss_fn._weight_bins(contributions, height, width)
+    _, _, present, _ = loss_fn._binning(height, width, prediction.device)
+    return present.float(), weighted.sum(dim=0)
+
+
+def share_above(
+    wavenumbers: torch.Tensor, contributions: torch.Tensor, cut: float
+) -> float:
+    """Fraction (%) of the total penalty carried by bins with |k| > cut."""
+    total = float(contributions.sum())
+    return 100.0 * float(contributions[wavenumbers > cut].sum()) / total
+
+
+class TestAMSELossWavenumberWeight:
+    """The optional FastNet upweighting gamma_k = max(N_k * k**sqrt(3), 1)."""
+
+    # Values produced by the implementation BEFORE wavenumber_weight existed
+    # (fields = make_fields(seed=11), CPU, float32). Any drift in the default
+    # path moves frozen anchors and existing runs, so it must fail here.
+    GOLDEN_HYBRID_VALUE = 7.9457767308e-02
+    GOLDEN_HYBRID_GRAD_NORM = 5.4061640985e-03
+    GOLDEN_PURE_VALUE = 1.8319147825e-01
+    GOLDEN_PURE_GRAD_NORM = 1.6285512596e-02
+    GOLDEN_EXCESS = (
+        1.9828230143e-02,
+        1.6821861267e-02,
+        1.6672907397e-02,
+        1.7617737874e-02,
+    )
+
+    def test_default_is_off(self) -> None:
+        assert AMSELoss().wavenumber_weight == "none"
+
+    def test_unknown_weight_raises(self) -> None:
+        with pytest.raises(ValueError, match="wavenumber_weight"):
+            AMSELoss(wavenumber_weight="fastnetish")
+
+    @pytest.mark.parametrize("off", [None, "none", "None", "NONE"])
+    @pytest.mark.parametrize("mode", ["hybrid", "pure"])
+    def test_off_is_bitwise_identical_to_default(
+        self, off: str | None, mode: AMSEMode
+    ) -> None:
+        """OFF must not perturb the existing loss by even one ulp."""
+        prediction, target = make_fields(seed=10)
+        prediction = prediction.requires_grad_()
+        reference = AMSELoss(mode=mode)(prediction, target)
+        (reference_grad,) = torch.autograd.grad(reference, prediction)
+        candidate = AMSELoss(mode=mode, wavenumber_weight=off)(prediction, target)
+        (candidate_grad,) = torch.autograd.grad(candidate, prediction)
+        assert torch.equal(reference, candidate)
+        assert torch.equal(reference_grad, candidate_grad)
+
+    def test_off_matches_pre_change_reference_values(self) -> None:
+        """Golden values captured from the implementation before this option."""
+        prediction, target = make_fields(seed=11)
+        prediction = prediction.requires_grad_()
+
+        hybrid = AMSELoss(mode="hybrid", spectral_weight=0.1)(prediction, target)
+        (hybrid_grad,) = torch.autograd.grad(hybrid, prediction)
+        assert hybrid.item() == pytest.approx(self.GOLDEN_HYBRID_VALUE, rel=1e-6)
+        assert hybrid_grad.norm().item() == pytest.approx(
+            self.GOLDEN_HYBRID_GRAD_NORM, rel=1e-6
+        )
+
+        pure = AMSELoss(mode="pure")(prediction, target)
+        (pure_grad,) = torch.autograd.grad(pure, prediction)
+        assert pure.item() == pytest.approx(self.GOLDEN_PURE_VALUE, rel=1e-6)
+        assert pure_grad.norm().item() == pytest.approx(
+            self.GOLDEN_PURE_GRAD_NORM, rel=1e-6
+        )
+
+        excess = AMSELoss().spectral_excess(prediction.detach(), target)
+        assert excess.tolist() == pytest.approx(list(self.GOLDEN_EXCESS), rel=1e-6)
+
+    @pytest.mark.parametrize(("height", "width"), [(32, 32), (31, 33), (48, 64)])
+    def test_gamma_matches_the_published_formula(self, height: int, width: int) -> None:
+        """gamma_k == max(N_k * k**sqrt(3), 1), N_k counted on the FULL 2D DFT."""
+        loss_fn = AMSELoss()
+        _, _, present, gamma = loss_fn._binning(height, width, torch.device("cpu"))
+        ky = np.fft.fftfreq(height) * height
+        kx = np.fft.fftfreq(width) * width
+        kmag = np.sqrt(ky[:, None] ** 2 + kx[None, :] ** 2)
+        bins = np.round(kmag).astype(int)
+        bins = np.where(
+            (bins >= 1) & (bins < loss_fn.merge_bins_below),
+            loss_fn.merge_bins_below,
+            bins,
+        )
+        n_bins = int(bins.max()) + 1
+        mode_counts = np.zeros(n_bins)
+        for i in range(height):
+            for j in range(width):
+                if i == 0 and j == 0:
+                    continue  # the DC mode belongs to no annulus
+                mode_counts[bins[i, j]] += 1.0
+        expected = np.maximum(mode_counts * np.arange(n_bins) ** math.sqrt(3.0), 1.0)[
+            present.numpy()
+        ]
+        assert gamma.numpy() == pytest.approx(expected, rel=1e-6)
+        # The whole plane is accounted for, DC excluded.
+        assert mode_counts.sum() == height * width - 1
+
+    def test_gamma_moves_the_penalty_to_fine_scales(self) -> None:
+        """The declared purpose: the high-|k| share of the penalty must rise."""
+        _, target = make_fields(seed=12, shape=(2, 2, 1, 64, 64))
+        prediction = blur(target, 5)
+        wavenumbers, unweighted = penalty_by_bin(AMSELoss(), prediction, target)
+        _, weighted = penalty_by_bin(
+            AMSELoss(wavenumber_weight="fastnet"), prediction, target
+        )
+        for cut in (4, 10, 20, 30):
+            assert share_above(wavenumbers, weighted, cut) > share_above(
+                wavenumbers, unweighted, cut
+            )
+
+        # ... and the median wavenumber of the penalty moves up.
+        def median_k(contributions: torch.Tensor) -> float:
+            cumulative = torch.cumsum(contributions / contributions.sum(), dim=0)
+            return float(wavenumbers[int(torch.searchsorted(cumulative, 0.5))])
+
+        assert median_k(weighted) > median_k(unweighted)
+
+    def test_gamma_preserves_the_batch_total(self) -> None:
+        """Scale-preserving normalisation: same magnitude, different shape."""
+        _, target = make_fields(seed=13, shape=(3, 2, 1, 32, 32))
+        prediction = blur(target, 3)
+        off = AMSELoss().spectral_excess(prediction, target)
+        on = AMSELoss(wavenumber_weight="fastnet").spectral_excess(prediction, target)
+        assert float(on.sum()) == pytest.approx(float(off.sum()), rel=1e-5)
+        # The redistribution is real: individual fields do move.
+        assert not torch.allclose(on, off, rtol=1e-3)
+
+    def test_gamma_changes_the_gradient_not_the_scalar_value(self) -> None:
+        """Same loss number, different descent direction (the point of the flag)."""
+        _, target = make_fields(seed=14, shape=(2, 2, 1, 32, 32))
+        blurred = blur(target, 3)
+        grads = []
+        for weight in (None, "fastnet"):
+            prediction = blurred.clone().requires_grad_()
+            loss = AMSELoss(spectral_weight=1.0, wavenumber_weight=weight)(
+                prediction, target
+            )
+            (gradient,) = torch.autograd.grad(loss, prediction)
+            grads.append((loss.detach().item(), gradient))
+        assert grads[0][0] == pytest.approx(grads[1][0], rel=1e-5)
+        cosine = float(
+            functional.cosine_similarity(
+                grads[0][1].flatten(), grads[1][1].flatten(), dim=0
+            )
+        )
+        assert cosine < 0.999
+        # The spectral branch stays the same order of magnitude, so the arm is
+        # trainable at the unweighted twin's learning rate.
+        ratio = float(grads[1][1].norm() / grads[0][1].norm())
+        assert 0.1 < ratio < 10.0
+
+    @pytest.mark.parametrize("mode", ["hybrid", "pure"])
+    def test_gamma_identity_is_zero(self, mode: AMSEMode) -> None:
+        """The 0/0 in the normaliser must not produce NaN for a perfect match."""
+        prediction, _ = make_fields(seed=15)
+        loss_fn = AMSELoss(mode=mode, wavenumber_weight="fastnet")
+        loss = loss_fn(prediction, prediction)
+        assert torch.isfinite(loss)
+        assert loss.item() == pytest.approx(0.0, abs=1e-6)
+
+    @pytest.mark.parametrize("mode", ["hybrid", "pure"])
+    @pytest.mark.parametrize("case", ["random", "zero", "masked", "identical"])
+    def test_gamma_loss_and_gradients_stay_finite(
+        self, mode: AMSEMode, case: str
+    ) -> None:
+        prediction, target = make_fields(seed=16)
+        if case == "zero":
+            prediction = torch.zeros_like(target)
+        elif case == "identical":
+            prediction = target.clone()
+        elif case == "masked":
+            mask = torch.zeros(32, 32)
+            mask[8:24, 8:24] = 1.0
+            prediction, target = prediction * mask, target * mask
+        prediction = prediction.detach().requires_grad_()
+        loss = AMSELoss(mode=mode, wavenumber_weight="fastnet")(prediction, target)
+        loss.backward()
+        assert torch.isfinite(loss)
+        assert prediction.grad is not None
+        assert torch.isfinite(prediction.grad).all()
+
+    def test_gamma_hybrid_still_reduces_to_huber_at_zero_weight(self) -> None:
+        prediction, target = make_fields(seed=17)
+        hybrid = AMSELoss(
+            mode="hybrid", spectral_weight=0.0, wavenumber_weight="fastnet"
+        )(prediction, target)
+        huber = functional.huber_loss(prediction, target, delta=0.5)
+        assert torch.allclose(hybrid, huber)
+
+    def test_gamma_leaves_the_dc_term_unweighted(self) -> None:
+        """A pure mean offset has no annular content: pure AMSE == the DC term."""
+        _, target = make_fields(seed=18)
+        prediction = target + 0.25
+        for weight in (None, "fastnet"):
+            loss = AMSELoss(mode="pure", wavenumber_weight=weight)(prediction, target)
+            assert loss.item() == pytest.approx(0.25**2, rel=1e-5)
+
+    def test_gamma_is_symmetric_and_low_precision_safe(self) -> None:
+        prediction, target = make_fields(seed=19)
+        loss_fn = AMSELoss(mode="pure", wavenumber_weight="fastnet")
+        assert torch.allclose(loss_fn(prediction, target), loss_fn(target, prediction))
+        low = AMSELoss(wavenumber_weight="fastnet")(
+            prediction.to(torch.bfloat16), target.to(torch.bfloat16)
+        )
+        assert low.dtype == torch.float32
+        assert torch.isfinite(low)
+
+    def test_gamma_blur_penalty_is_still_monotone_in_blur_width(self) -> None:
+        _, target = make_fields(seed=20)
+        loss_fn = AMSELoss(wavenumber_weight="fastnet")
+        light = loss_fn.spectral_excess(blur(target, 3), target).mean()
+        heavy = loss_fn.spectral_excess(blur(target, 7), target).mean()
+        assert light.item() > 0.0
+        assert heavy.item() > light.item()
+
+    def test_config_instantiation_with_weight(self) -> None:
+        config = OmegaConf.create(
+            {
+                "_target_": "icenet_mp.losses.amse_loss.AMSELoss",
+                "mode": "hybrid",
+                "spectral_weight": 0.1,
+                "wavenumber_weight": "fastnet",
+            }
+        )
+        loss_fn = hydra.utils.instantiate(config)
+        assert isinstance(loss_fn, AMSELoss)
+        assert loss_fn.wavenumber_weight == "fastnet"

--- a/tests/models/test_amse_loss.py
+++ b/tests/models/test_amse_loss.py
@@ -1,0 +1,136 @@
+import hydra
+import pytest
+import torch
+from omegaconf import OmegaConf
+from torch.nn import functional
+
+from icenet_mp.losses.amse_loss import AMSELoss
+
+
+def make_fields(
+    seed: int = 0, shape: tuple[int, ...] = (2, 2, 1, 32, 32)
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return a seeded (prediction, target) pair of random fields."""
+    generator = torch.Generator().manual_seed(seed)
+    prediction = torch.rand(*shape, generator=generator)
+    target = torch.rand(*shape, generator=generator)
+    return prediction, target
+
+
+def blur(field: torch.Tensor, kernel_size: int) -> torch.Tensor:
+    """Box-blur the trailing spatial dimensions of an [N, T, C, H, W] tensor."""
+    n, t, c, h, w = field.shape
+    flat = field.reshape(n * t * c, 1, h, w)
+    kernel = torch.ones(1, 1, kernel_size, kernel_size) / kernel_size**2
+    blurred = functional.conv2d(flat, kernel, padding=kernel_size // 2)
+    return blurred.reshape(n, t, c, h, w)
+
+
+class TestAMSELoss:
+    def test_config_instantiation(self) -> None:
+        config = OmegaConf.create(
+            {
+                "_target_": "icenet_mp.losses.amse_loss.AMSELoss",
+                "mode": "hybrid",
+                "spectral_weight": 0.1,
+            }
+        )
+        loss_fn = hydra.utils.instantiate(config)
+        assert isinstance(loss_fn, AMSELoss)
+
+    def test_unknown_mode_raises(self) -> None:
+        with pytest.raises(ValueError, match="mode"):
+            AMSELoss(mode="not-a-mode")
+        with pytest.raises(ValueError, match="merge_bins_below"):
+            AMSELoss(merge_bins_below=0)
+
+    @pytest.mark.parametrize("mode", ["hybrid", "pure"])
+    def test_identity_is_zero(self, mode: str) -> None:
+        prediction, _ = make_fields()
+        loss_fn = AMSELoss(mode=mode)
+        assert loss_fn(prediction, prediction).item() == pytest.approx(0.0, abs=1e-6)
+
+    def test_scalar_output(self) -> None:
+        prediction, target = make_fields()
+        loss = AMSELoss()(prediction, target)
+        assert loss.shape == ()
+        assert torch.isfinite(loss)
+
+    def test_parseval_identity(self) -> None:
+        """Binned spectra must reconstruct the spatial MSE exactly (Parseval)."""
+        prediction, target = make_fields(seed=1)
+        loss_fn = AMSELoss()
+        power_p, power_t, cross, dc = loss_fn.binned_spectra(prediction, target)
+        spectral_mse = (power_p + power_t - 2.0 * cross).sum(dim=1) + dc
+        spatial_mse = (
+            ((prediction - target) ** 2).reshape(spectral_mse.shape[0], -1).mean(dim=1)
+        )
+        assert torch.allclose(spectral_mse, spatial_mse, rtol=1e-4, atol=1e-7)
+
+    def test_parseval_identity_odd_grid(self) -> None:
+        """The rfft factor-2 bookkeeping must also hold for odd widths."""
+        prediction, target = make_fields(seed=2, shape=(2, 1, 1, 31, 33))
+        loss_fn = AMSELoss()
+        power_p, power_t, cross, dc = loss_fn.binned_spectra(prediction, target)
+        spectral_mse = (power_p + power_t - 2.0 * cross).sum(dim=1) + dc
+        spatial_mse = (
+            ((prediction - target) ** 2).reshape(spectral_mse.shape[0], -1).mean(dim=1)
+        )
+        assert torch.allclose(spectral_mse, spatial_mse, rtol=1e-4, atol=1e-7)
+
+    def test_blur_is_penalized_and_monotone(self) -> None:
+        """The spectral excess is positive for blurred predictions and grows with blur width."""
+        _, target = make_fields(seed=3)
+        loss_fn = AMSELoss()
+        excess_light = loss_fn.spectral_excess(blur(target, 3), target).mean()
+        excess_heavy = loss_fn.spectral_excess(blur(target, 7), target).mean()
+        assert excess_light.item() > 0.0
+        assert excess_heavy.item() > excess_light.item()
+
+    def test_amplitude_gradient_points_up(self) -> None:
+        """For a uniformly damped prediction the spectral gradient pushes amplitude up."""
+        _, target = make_fields(seed=4)
+        scale = torch.tensor(0.5, requires_grad=True)
+        excess = AMSELoss().spectral_excess(scale * target, target).mean()
+        (gradient,) = torch.autograd.grad(excess, scale)
+        assert gradient.item() < 0.0
+
+    @pytest.mark.parametrize("mode", ["hybrid", "pure"])
+    def test_zero_field_gradients_finite(self, mode: str) -> None:
+        _, target = make_fields(seed=5)
+        prediction = torch.zeros_like(target, requires_grad=True)
+        loss = AMSELoss(mode=mode)(prediction, target)
+        loss.backward()
+        assert prediction.grad is not None
+        assert torch.isfinite(prediction.grad).all()
+
+    @pytest.mark.parametrize("mode", ["hybrid", "pure"])
+    def test_masked_fields(self, mode: str) -> None:
+        """Fields zeroed outside an active region give finite loss and gradients."""
+        prediction, target = make_fields(seed=6)
+        mask = torch.zeros(32, 32)
+        mask[8:24, 8:24] = 1.0
+        prediction = (prediction * mask).detach().requires_grad_()
+        target = target * mask
+        loss = AMSELoss(mode=mode)(prediction, target)
+        loss.backward()
+        assert torch.isfinite(loss)
+        assert prediction.grad is not None
+        assert torch.isfinite(prediction.grad).all()
+
+    def test_spectral_part_is_symmetric(self) -> None:
+        prediction, target = make_fields(seed=7)
+        loss_fn = AMSELoss(mode="pure")
+        assert torch.allclose(loss_fn(prediction, target), loss_fn(target, prediction))
+
+    def test_hybrid_reduces_to_huber_at_zero_weight(self) -> None:
+        prediction, target = make_fields(seed=8)
+        hybrid = AMSELoss(mode="hybrid", spectral_weight=0.0)(prediction, target)
+        huber = functional.huber_loss(prediction, target, delta=0.5)
+        assert torch.allclose(hybrid, huber)
+
+    def test_low_precision_input(self) -> None:
+        prediction, target = make_fields(seed=9)
+        loss = AMSELoss()(prediction.to(torch.bfloat16), target.to(torch.bfloat16))
+        assert loss.dtype == torch.float32
+        assert torch.isfinite(loss)

--- a/tests/models/test_loss_config.py
+++ b/tests/models/test_loss_config.py
@@ -5,6 +5,7 @@ import torch
 from hydra.errors import InstantiationException
 from omegaconf import DictConfig, OmegaConf
 
+from icenet_mp.losses.amse_loss import AMSELoss
 from icenet_mp.losses.rmse_loss import RMSELoss
 from icenet_mp.models import BaseModel
 from icenet_mp.types import TensorNTCHW
@@ -27,6 +28,7 @@ LOSS_CONFIGS = {
     "huber": OmegaConf.create({"_target_": "torch.nn.HuberLoss", "delta": 0.5}),
     "smooth_l1": OmegaConf.create({"_target_": "torch.nn.SmoothL1Loss", "beta": 0.5}),
     "rmse": OmegaConf.create({"_target_": "icenet_mp.losses.rmse_loss.RMSELoss"}),
+    "amse": OmegaConf.create({"_target_": "icenet_mp.losses.amse_loss.AMSELoss"}),
 }
 
 LOSS_TYPES = {
@@ -35,6 +37,7 @@ LOSS_TYPES = {
     "huber": torch.nn.HuberLoss,
     "smooth_l1": torch.nn.SmoothL1Loss,
     "rmse": RMSELoss,
+    "amse": AMSELoss,
 }
 
 


### PR DESCRIPTION
Closes #304  This is a flat domain variance of the Adjusted spherical-harmonic MSE (AMSE) of Subich et al. (2025), arXiv:2501.19374. 

This variance uses the FFT-spectral annular-bin power/coherence terms with the original paper's maximum decorrelation weighting, and in addition a hybrid mode (Huber + weighted AMSE excess) that reduces to the default Huber loss at spectral_weight=0. Selectable via 'imp train loss=amse' (or config file loss=amse).

Implementation notes:
- Scale groups: annular bins of isotropic wavenumber |k| from a 2D DFT, note: on the fixed area EASE2 grid, Parseval's identity makes the spectral decomposition of MSE exact, the boundary ring is inactive (both 0 in prediction and in target), so the DFT periodicity assumption wont introduce boundary discontinuity.
- Two modes: (a) hybrid (default) = Huber + spectral_weight * (AMSE − MSE), returns to exactly to the default Huber loss at `spectral_weight=0`;  (b) pure = Eq (6) of  Subich et al. (2025).
- Numerical guards and other computational details mirror the reference implementation (the original github repo of AMSE) with some adaptations.
- One class, one config file; no changes to the training code (uses the loss config group from #283). Scope: spatial-field predictions; untested with losses computed in other spaces (e.g. DDPM v-space).

## Testing
- New tests/models/test_amse_loss.py (13 tests): Hydra instantiation; fail-loud arg validation; loss(x,x)=0; Parseval reconstruction of the spatial MSE on even and odd grids (pins the FFT/binning/factor-2 bookkeeping); blur penalized monotonically; amplitude gradient points upward for damped predictions; finite gradients for all-zero fields; masked-field sanity; symmetry; exact Huber spectral_weight=0; bf16 input safety.
- tests/models/test_loss_config.py: amse added to the param
- Full suite: 941 passed, 1 skipped. pre-commit run --all-files and mypy .clean.
- End-to-end: composes and trains with --config-name=baseline/ predict=sic-ssmis-14d; a 50-epoch A/B against `loss=huber` (same seed, early stopping disabled in both arms) is running spectral PSD ratio and coherence against lead day) to follow on the issue.